### PR TITLE
Migrate to color-fns

### DIFF
--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -1,13 +1,12 @@
 import React, { useState } from "react";
 import ReactDOM from "react-dom";
-import tinycolor from "tinycolor2";
+import { isDark, hexToRgb } from "color-fns";
 import ColorPicker from "../../src";
 import styles from "./styles.css";
 
 const Demo = () => {
-  const [color, setColor] = useState("#C92281");
-
-  const textColor = tinycolor(color).isLight() ? "#111" : "#FFF";
+  const [color, setColor] = useState("#c92281");
+  const textColor = isDark(hexToRgb(color)) ? "#FFF" : "#000";
 
   return (
     <div className={styles.wrapper} style={{ color: textColor, backgroundColor: color }}>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "umd:main": "dist/index.umd.js",
   "scripts": {
     "lint": "eslint src/**/*.js examples/src/**/*.js",
-    "size": "size-limit",
+    "size": "npm run build && size-limit",
     "test": "uvu -r esm tests",
     "build": "microbundle --entry src/index.js --output dist/index.js --name react-colorful --css-modules",
     "start-demo": "parcel demo/src/index.html --out-dir demo/dist --open",
@@ -18,7 +18,7 @@
   },
   "size-limit": [
     {
-      "path": "src/index.js",
+      "path": "dist/index.js",
       "limit": "1.5 KB"
     }
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-colorful",
-  "version": "0.0.92",
+  "version": "0.0.93",
   "description": "A tiny color picker component for modern React apps",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "lint": "eslint src/**/*.js examples/src/**/*.js",
     "size": "size-limit",
-    "test": "npm run size",
+    "test": "uvu -r esm tests",
     "build": "microbundle --entry src/index.js --output dist/index.js --name react-colorful --css-modules",
     "start-demo": "parcel demo/src/index.html --out-dir demo/dist --open",
     "build-demo": "del-cli 'demo/dist/*' && parcel build demo/src/index.html --out-dir demo/dist --public-url /react-colorful/",
@@ -53,6 +53,7 @@
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-react": "^7.20.3",
     "eslint-plugin-react-hooks": "^4.0.8",
+    "esm": "^3.2.25",
     "gh-pages": "^3.1.0",
     "microbundle": "^0.12.3",
     "parcel-bundler": "^1.12.4",
@@ -60,9 +61,10 @@
     "prettier": "2.0.5",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "size-limit": "^4.5.5"
+    "size-limit": "^4.5.5",
+    "uvu": "^0.3.1"
   },
   "dependencies": {
-    "tinycolor2": "^1.4.1"
+    "color-fns": "^0.1.1"
   }
 }

--- a/src/components/ColorPicker.js
+++ b/src/components/ColorPicker.js
@@ -15,7 +15,7 @@ const ColorPicker = ({ className, hex, onChange }) => {
   }, [hsv, onChange]);
 
   // Merge the current HSV color object with updated params.
-  // For example, when a child component sends `h` or `s` only
+  // For example, when a child component sends `hue` or `sat` only
   const handleChange = useCallback(
     (params) => updateHsv((current) => Object.assign({}, current, params)),
     []
@@ -26,7 +26,7 @@ const ColorPicker = ({ className, hex, onChange }) => {
   return (
     <div className={nodeClassName}>
       <Saturation hsv={hsv} onChange={handleChange} />
-      <Hue hue={hsv.h} onChange={handleChange} />
+      <Hue hue={hsv.hue} onChange={handleChange} />
     </div>
   );
 };

--- a/src/components/ColorPicker.js
+++ b/src/components/ColorPicker.js
@@ -1,17 +1,17 @@
 import React, { useState, useEffect, useCallback } from "react";
 import Hue from "./Hue";
 import Saturation from "./Saturation";
-import { toHexString, toHsv, formatClassName } from "../utils";
+import { hsvToHex, hexToHsv, formatClassName } from "../utils";
 import styles from "../styles.css";
 
 const ColorPicker = ({ className, hex, onChange }) => {
   // Input and output formats are HEX (#AAAAAA),
   // but all internal calculations are based on HSV model
-  const [hsv, updateHsv] = useState(() => toHsv(hex));
+  const [hsv, updateHsv] = useState(() => hexToHsv(hex));
 
   // Convert updated HSV to HEX-format and send it to the parent component
   useEffect(() => {
-    onChange(toHexString(hsv));
+    onChange(hsvToHex(hsv));
   }, [hsv, onChange]);
 
   // Merge the current HSV color object with updated params.

--- a/src/components/Hue.js
+++ b/src/components/Hue.js
@@ -7,7 +7,7 @@ const Hue = ({ className, hue, onChange }) => {
   const handleMove = useCallback(
     (interaction) => {
       // Hue measured in degrees of the color circle ranging from 0 to 360
-      onChange({ h: 360 * interaction.left });
+      onChange({ hue: 360 * interaction.left });
     },
     [onChange]
   );
@@ -15,7 +15,7 @@ const Hue = ({ className, hue, onChange }) => {
   const pointerStyle = {
     top: "50%",
     left: `${(hue / 360) * 100}%`,
-    backgroundColor: toHexString({ h: hue, s: 1, l: 0.5 }),
+    backgroundColor: toHexString({ hue, sat: 100, val: 100 }),
   };
 
   const nodeClassName = formatClassName(["react-colorful__hue", styles.hue, className]);

--- a/src/components/Hue.js
+++ b/src/components/Hue.js
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import Interactive from "./Interactive";
-import { toHexString, formatClassName } from "../utils";
+import { hsvToHex, formatClassName } from "../utils";
 import styles from "../styles.css";
 
 const Hue = ({ className, hue, onChange }) => {
@@ -15,7 +15,7 @@ const Hue = ({ className, hue, onChange }) => {
   const pointerStyle = {
     top: "50%",
     left: `${(hue / 360) * 100}%`,
-    backgroundColor: toHexString({ hue, sat: 100, val: 100 }),
+    backgroundColor: hsvToHex({ hue, sat: 100, val: 100 }),
   };
 
   const nodeClassName = formatClassName(["react-colorful__hue", styles.hue, className]);

--- a/src/components/Saturation.js
+++ b/src/components/Saturation.js
@@ -6,21 +6,21 @@ import styles from "../styles.css";
 const Saturation = ({ className, hsv, onChange }) => {
   const handleMove = useCallback(
     (interaction) => {
-      // Saturation and brightness always fit into [0, 1] range
-      const saturation = interaction.left;
-      const brightness = 1 - interaction.top;
-      onChange({ s: saturation, v: brightness });
+      // Saturation and brightness always fit into [0, 100] range
+      const saturation = interaction.left * 100;
+      const brightness = 100 - interaction.top * 100;
+      onChange({ sat: saturation, val: brightness });
     },
     [onChange]
   );
 
   const containerStyle = {
-    backgroundColor: toHexString({ h: hsv.h, s: 1, l: 0.5 }),
+    backgroundColor: toHexString({ hue: hsv.hue, sat: 100, val: 100 }),
   };
 
   const pointerStyle = {
-    top: `${100 - hsv.v * 100}%`,
-    left: `${hsv.s * 100}%`,
+    top: `${100 - hsv.val}%`,
+    left: `${hsv.sat}%`,
     backgroundColor: toHexString(hsv),
   };
 

--- a/src/components/Saturation.js
+++ b/src/components/Saturation.js
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import Interactive from "./Interactive";
-import { toHexString, formatClassName } from "../utils";
+import { hsvToHex, formatClassName } from "../utils";
 import styles from "../styles.css";
 
 const Saturation = ({ className, hsv, onChange }) => {
@@ -15,13 +15,13 @@ const Saturation = ({ className, hsv, onChange }) => {
   );
 
   const containerStyle = {
-    backgroundColor: toHexString({ hue: hsv.hue, sat: 100, val: 100 }),
+    backgroundColor: hsvToHex({ hue: hsv.hue, sat: 100, val: 100 }),
   };
 
   const pointerStyle = {
     top: `${100 - hsv.val}%`,
     left: `${hsv.sat}%`,
-    backgroundColor: toHexString(hsv),
+    backgroundColor: hsvToHex(hsv),
   };
 
   const nodeClassName = formatClassName([

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,8 @@
-import tinycolor from "tinycolor2";
+import { rgbToHsv, hexToRgb, rgbToHex, hsvToRgb, formatHex } from "color-fns";
 
-export const toHsv = (color) => tinycolor(color).toHsv();
+export const toHsv = (hex) => rgbToHsv(hexToRgb(hex));
 
-export const toHexString = (color) => tinycolor(color).toHexString().toUpperCase();
+export const toHexString = (hsv) => formatHex(rgbToHex(hsvToRgb(hsv)));
 
 export const limit = (number, min = 0, max = 1) => Math.min(Math.max(min, number), max);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,9 +1,9 @@
 import { rgbToHsv, hexToRgb, rgbToHex, hsvToRgb, formatHex } from "color-fns";
 
-export const toHsv = (hex) => rgbToHsv(hexToRgb(hex));
+export const hexToHsv = (hex) => rgbToHsv(hexToRgb(hex));
 
-export const toHexString = (hsv) => formatHex(rgbToHex(hsvToRgb(hsv)));
+export const hsvToHex = (hsv) => formatHex(rgbToHex(hsvToRgb(hsv)));
 
 export const limit = (number, min = 0, max = 1) => Math.min(Math.max(min, number), max);
 
-export const formatClassName = (array) => array.filter(Boolean).join(" ");
+export const formatClassName = (array = []) => array.filter(Boolean).join(" ");

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,44 +1,35 @@
 import { test } from "uvu";
 import * as assert from "uvu/assert";
-import { toHsv, toHexString } from "../src/utils.js";
+import { hexToHsv, hsvToHex, formatClassName } from "../src/utils.js";
 
-const colors = {
-  white: {
-    hexString: "#ffffff",
-    shortHexString: "#fff",
-    hsv: { hue: 0, sat: 0, val: 100, alpha: 1 },
-  },
-  black: {
-    hexString: "#000000",
-    shortHexString: "#000",
-    hsv: { hue: 0, sat: 0, val: 0, alpha: 1 },
-  },
-  yellow: {
-    hexString: "#ffff00",
-    shortHexString: "#ff0",
-    hsv: { hue: 60, sat: 100, val: 100, alpha: 1 },
-  },
-};
-
-test("HEX to HSV", () => {
-  for (let name in colors) {
-    let { hexString, hsv } = colors[name];
-    assert.equal(toHsv(hexString), hsv);
-  }
+test("Converts HEX to HSV", () => {
+  assert.equal(hexToHsv("#ffffff"), { hue: 0, sat: 0, val: 100, alpha: 1 });
+  assert.equal(hexToHsv("#ffff00"), { hue: 60, sat: 100, val: 100, alpha: 1 });
+  assert.equal(hexToHsv("#ff0000"), { hue: 0, sat: 100, val: 100, alpha: 1 });
+  assert.equal(hexToHsv("#000000"), { hue: 0, sat: 0, val: 0, alpha: 1 });
+  assert.equal(hexToHsv("#c62182"), { hue: 324, sat: 83, val: 77, alpha: 1 });
 });
 
-test("Shorthand HEX to HSV", () => {
-  for (let name in colors) {
-    let { shortHexString, hsv } = colors[name];
-    if (shortHexString) assert.equal(toHsv(shortHexString), hsv);
-  }
+test("Converts shorthand HEX to HSV", () => {
+  assert.equal(hexToHsv("#FFF"), { hue: 0, sat: 0, val: 100, alpha: 1 });
+  assert.equal(hexToHsv("#FF0"), { hue: 60, sat: 100, val: 100, alpha: 1 });
+  assert.equal(hexToHsv("#F00"), { hue: 0, sat: 100, val: 100, alpha: 1 });
+  assert.equal(hexToHsv("#ABC"), { hue: 210, sat: 16, val: 80, alpha: 1 });
 });
 
-test("HSV to HEX", () => {
-  for (let name in colors) {
-    let { hexString, hsv } = colors[name];
-    assert.is(toHexString(hsv), hexString);
-  }
+test("Converts HSV to HEX", () => {
+  assert.is(hsvToHex({ hue: 0, sat: 0, val: 100, alpha: 1 }), "#ffffff");
+  assert.is(hsvToHex({ hue: 60, sat: 100, val: 100, alpha: 1 }), "#ffff00");
+  assert.is(hsvToHex({ hue: 0, sat: 100, val: 100, alpha: 1 }), "#ff0000");
+  assert.is(hsvToHex({ hue: 0, sat: 0, val: 0, alpha: 1 }), "#000000");
+  assert.is(hsvToHex({ hue: 284, sat: 93, val: 73, alpha: 1 }), "#8b0dba");
+});
+
+test("Formats a class name", () => {
+  assert.is(formatClassName(), "");
+  assert.is(formatClassName(["one"]), "one");
+  assert.is(formatClassName(["one", "two", "three"]), "one two three");
+  assert.is(formatClassName([false, "two", null]), "two");
 });
 
 test.run();

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,44 @@
+import { test } from "uvu";
+import * as assert from "uvu/assert";
+import { toHsv, toHexString } from "../src/utils.js";
+
+const colors = {
+  white: {
+    hexString: "#ffffff",
+    shortHexString: "#fff",
+    hsv: { hue: 0, sat: 0, val: 100, alpha: 1 },
+  },
+  black: {
+    hexString: "#000000",
+    shortHexString: "#000",
+    hsv: { hue: 0, sat: 0, val: 0, alpha: 1 },
+  },
+  yellow: {
+    hexString: "#ffff00",
+    shortHexString: "#ff0",
+    hsv: { hue: 60, sat: 100, val: 100, alpha: 1 },
+  },
+};
+
+test("HEX to HSV", () => {
+  for (let name in colors) {
+    let { hexString, hsv } = colors[name];
+    assert.equal(toHsv(hexString), hsv);
+  }
+});
+
+test("Shorthand HEX to HSV", () => {
+  for (let name in colors) {
+    let { shortHexString, hsv } = colors[name];
+    if (shortHexString) assert.equal(toHsv(shortHexString), hsv);
+  }
+});
+
+test("HSV to HEX", () => {
+  for (let name in colors) {
+    let { hexString, hsv } = colors[name];
+    assert.is(toHexString(hsv), hexString);
+  }
+});
+
+test.run();


### PR DESCRIPTION
Replaced `tinycolor2` with `color-fns`.

`color-fns` is modular and tree-shakable (inspired by date-fns).
```js
// 3,7 KB (1,6 gzipped)
import { rgbToHsv, hexToRgb, rgbToHex, hsvToRgb, formatHex } from "color-fns";
```
vs
```js
// 15 KB (5,3 gzipped)
import tinycolor from "tinycolor2";
```
