### PR TITLE
Migrate to @swiftcarrot/color-fns

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "uvu": "^0.3.1"
   },
   "dependencies": {
+    "@swiftcarrot/color-fns": "^3.1.1",
     "color-fns": "^0.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@size-limit/preset-app": "^4.5.5",
+    "color-fns": "^0.1.1",
     "del-cli": "^3.0.1",
     "eslint": "^7.5.0",
     "eslint-config-prettier": "^6.11.0",
@@ -67,7 +68,6 @@
     "uvu": "^0.3.1"
   },
   "dependencies": {
-    "@swiftcarrot/color-fns": "^3.1.1",
-    "color-fns": "^0.1.1"
+    "@swiftcarrot/color-fns": "^3.1.2"
   }
 }

--- a/src/components/ColorPicker.js
+++ b/src/components/ColorPicker.js
@@ -38,7 +38,7 @@ const ColorPicker = ({ className, hex, onChange }) => {
   return (
     <div className={nodeClassName}>
       <Saturation hsv={hsv} onChange={handleChange} />
-      <Hue hue={hsv.hue} onChange={handleChange} />
+      <Hue hue={hsv.h} onChange={handleChange} />
     </div>
   );
 };

--- a/src/components/Hue.js
+++ b/src/components/Hue.js
@@ -7,7 +7,7 @@ const Hue = ({ className, hue, onChange }) => {
   const handleMove = useCallback(
     (interaction) => {
       // Hue measured in degrees of the color circle ranging from 0 to 360
-      onChange({ hue: 360 * interaction.left });
+      onChange({ h: 360 * interaction.left });
     },
     [onChange]
   );
@@ -15,7 +15,7 @@ const Hue = ({ className, hue, onChange }) => {
   const pointerStyle = {
     top: "50%",
     left: `${(hue / 360) * 100}%`,
-    backgroundColor: hsvToHex({ hue, sat: 100, val: 100 }),
+    backgroundColor: hsvToHex({ h: hue, s: 100, v: 100 }),
   };
 
   const nodeClassName = formatClassName(["react-colorful__hue", styles.hue, className]);

--- a/src/components/Saturation.js
+++ b/src/components/Saturation.js
@@ -9,18 +9,18 @@ const Saturation = ({ className, hsv, onChange }) => {
       // Saturation and brightness always fit into [0, 100] range
       const saturation = interaction.left * 100;
       const brightness = 100 - interaction.top * 100;
-      onChange({ sat: saturation, val: brightness });
+      onChange({ s: saturation, v: brightness });
     },
     [onChange]
   );
 
   const containerStyle = {
-    backgroundColor: hsvToHex({ hue: hsv.hue, sat: 100, val: 100 }),
+    backgroundColor: hsvToHex({ h: hsv.h, s: 100, v: 100 }),
   };
 
   const pointerStyle = {
-    top: `${100 - hsv.val}%`,
-    left: `${hsv.sat}%`,
+    top: `${100 - hsv.v}%`,
+    left: `${hsv.s}%`,
     backgroundColor: hsvToHex(hsv),
   };
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,8 +1,16 @@
-import { rgbToHsv, hexToRgb, rgbToHex, hsvToRgb, formatHex } from "color-fns";
+import { hex2rgb, rgb2hsv, hsv2rgb, rgb2hex } from "@swiftcarrot/color-fns";
 
-export const hexToHsv = (hex) => rgbToHsv(hexToRgb(hex));
+console.log(hsv2rgb({ h: 360, s: 50, v: 50 }));
 
-export const hsvToHex = (hsv) => formatHex(rgbToHex(hsvToRgb(hsv)));
+export const hexToHsv = (hex) => {
+  const { r, g, b } = hex2rgb(hex);
+  return rgb2hsv(r, g, b);
+};
+
+export const hsvToHex = ({ h, s, v }) => {
+  const { r, g, b } = hsv2rgb(h, s, v);
+  return rgb2hex(r, g, b);
+};
 
 export const limit = (number, min = 0, max = 1) => Math.min(Math.max(min, number), max);
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,16 +1,11 @@
-import { hex2rgb, rgb2hsv, hsv2rgb, rgb2hex } from "@swiftcarrot/color-fns";
-
-console.log(hsv2rgb({ h: 360, s: 50, v: 50 }));
+import { hex2rgb, rgb2hsv, hsv2hex } from "@swiftcarrot/color-fns";
 
 export const hexToHsv = (hex) => {
   const { r, g, b } = hex2rgb(hex);
   return rgb2hsv(r, g, b);
 };
 
-export const hsvToHex = ({ h, s, v }) => {
-  const { r, g, b } = hsv2rgb(h, s, v);
-  return rgb2hex(r, g, b);
-};
+export const hsvToHex = ({ h, s, v }) => hsv2hex(h, s, v);
 
 export const limit = (number, min = 0, max = 1) => Math.min(Math.max(min, number), max);
 

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,35 +1,35 @@
 import { test } from "uvu";
-import * as assert from "uvu/assert";
+import { equal, is } from "uvu/assert";
 import { hexToHsv, hsvToHex, formatClassName } from "../src/utils.js";
 
 test("Converts HEX to HSV", () => {
-  assert.equal(hexToHsv("#ffffff"), { hue: 0, sat: 0, val: 100, alpha: 1 });
-  assert.equal(hexToHsv("#ffff00"), { hue: 60, sat: 100, val: 100, alpha: 1 });
-  assert.equal(hexToHsv("#ff0000"), { hue: 0, sat: 100, val: 100, alpha: 1 });
-  assert.equal(hexToHsv("#000000"), { hue: 0, sat: 0, val: 0, alpha: 1 });
-  assert.equal(hexToHsv("#c62182"), { hue: 324, sat: 83, val: 77, alpha: 1 });
+  equal(hexToHsv("#ffffff"), { h: 0, s: 0, v: 100 });
+  equal(hexToHsv("#ffff00"), { h: 60, s: 100, v: 100 });
+  equal(hexToHsv("#ff0000"), { h: 0, s: 100, v: 100 });
+  equal(hexToHsv("#000000"), { h: 0, s: 0, v: 0 });
+  equal(hexToHsv("#c62182"), { h: 325, s: 83, v: 78 });
 });
 
 test("Converts shorthand HEX to HSV", () => {
-  assert.equal(hexToHsv("#FFF"), { hue: 0, sat: 0, val: 100, alpha: 1 });
-  assert.equal(hexToHsv("#FF0"), { hue: 60, sat: 100, val: 100, alpha: 1 });
-  assert.equal(hexToHsv("#F00"), { hue: 0, sat: 100, val: 100, alpha: 1 });
-  assert.equal(hexToHsv("#ABC"), { hue: 210, sat: 16, val: 80, alpha: 1 });
+  equal(hexToHsv("#FFF"), { h: 0, s: 0, v: 100 });
+  equal(hexToHsv("#FF0"), { h: 60, s: 100, v: 100 });
+  equal(hexToHsv("#F00"), { h: 0, s: 100, v: 100 });
+  equal(hexToHsv("#ABC"), { h: 210, s: 17, v: 80 });
 });
 
 test("Converts HSV to HEX", () => {
-  assert.is(hsvToHex({ hue: 0, sat: 0, val: 100, alpha: 1 }), "#ffffff");
-  assert.is(hsvToHex({ hue: 60, sat: 100, val: 100, alpha: 1 }), "#ffff00");
-  assert.is(hsvToHex({ hue: 0, sat: 100, val: 100, alpha: 1 }), "#ff0000");
-  assert.is(hsvToHex({ hue: 0, sat: 0, val: 0, alpha: 1 }), "#000000");
-  assert.is(hsvToHex({ hue: 284, sat: 93, val: 73, alpha: 1 }), "#8b0dba");
+  is(hsvToHex({ h: 0, s: 0, v: 100 }), "#ffffff");
+  is(hsvToHex({ h: 60, s: 100, v: 100 }), "#ffff00");
+  is(hsvToHex({ h: 0, s: 100, v: 100 }), "#ff0000");
+  is(hsvToHex({ h: 0, s: 0, v: 0 }), "#000000");
+  is(hsvToHex({ h: 284, s: 93, v: 73 }), "#8c0dba");
 });
 
 test("Formats a class name", () => {
-  assert.is(formatClassName(), "");
-  assert.is(formatClassName(["one"]), "one");
-  assert.is(formatClassName(["one", "two", "three"]), "one two three");
-  assert.is(formatClassName([false, "two", null]), "two");
+  is(formatClassName(), "");
+  is(formatClassName(["one"]), "one");
+  is(formatClassName(["one", "two", "three"]), "one two three");
+  is(formatClassName([false, "two", null]), "two");
 });
 
 test.run();


### PR DESCRIPTION
Migrate from `color-fns` to [`@swiftcarrot/color-fns`](https://github.com/swiftcarrot/color-fns) which:
- well supported by authors (~2 updates per month).
- has better test coverage.
- 1,6 times lighter:
![Xnip2020-08-07_11-59-51](https://user-images.githubusercontent.com/206567/89630250-c38a9a00-d8a7-11ea-8cf6-29f59bb2c461.jpg)
- Uses a more popular HSV object structure (`{h,s,v}` instead of `{hue, sat, val, alpha}`).