### PR TITLE
Replace `prepublish` deprecated npm step with `prepublishOnly`

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "size": "npm run build && size-limit",
     "test": "uvu -r esm tests",
     "build": "microbundle --entry src/index.js --output dist/index.js --name react-colorful --css-modules --jsx React.createElement",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "start-demo": "parcel demo/src/index.html --out-dir demo/dist --open",
     "build-demo": "del-cli 'demo/dist/*' && parcel build demo/src/index.html --out-dir demo/dist --public-url /react-colorful/",
     "deploy-demo": "npm run build-demo && gh-pages -d demo/dist"


### PR DESCRIPTION
The current `prepublish` script which builds the library runs on `npm install` and that seems confusing. Moreover, the `prepublish` seems to be deprecated as of npm@5:

> Deprecation Note: prepublish
>
> Since npm@1.1.71, the npm CLI has run the prepublish script for both
> npm  publish  and npm install, because it's a convenient way to pre-
> pare a package for use (some common use cases are described  in  the
> section  below).   It  has  also turned out to be, in practice, very
> confusing https://github.com/npm/npm/issues/10074.  As of npm@4.0.0,
> a new event has been introduced, prepare, that preserves this exist-
> ing behavior. A new event, prepublishOnly has been added as a  tran-
> sitional  strategy to allow users to avoid the confusing behavior of
> existing npm versions and only run on  npm  publish  (for  instance,
> running the tests one last time to ensure they're in good shape).
>
> See  https://github.com/npm/npm/issues/10074  for  a  much lengthier
> justification, with further reading, for this change.

(`npm help scripts`)

Here is a quick cheat sheet of when to use which event:
  - `prepare` - build the library on the side of the user. if you need to build a native module for example.
  - `prepublishOnly` – when you need to build the files that are going to be published on the registry.