### PR TITLE
Optimizations: Make the default bundle lighter

### DIFF
--- a/ACKNOWLEDGMENTS
+++ b/ACKNOWLEDGMENTS
@@ -1,3 +1,4 @@
 ## Acknowledgements
 
-- In order to reduce the bundle size and avoid tree-shaking problems, `hsvToRgb`, `rgbToHex` and `hexToRgb` methods were copied from [@swiftcarrot/color-fns](https://github.com/swiftcarrot/color-fns) (MIT License).
+- In order to reduce the bundle size and avoid tree-shaking problems, `rgbToHex` and `hexToRgb` methods were copied from [@swiftcarrot/color-fns](https://github.com/swiftcarrot/color-fns) (MIT License).
+- `hsvToRgb` modified from https://axonflux.com/handy-rgb-to-hsl-and-rgb-to-hsv-color-model-c.

--- a/ACKNOWLEDGMENTS
+++ b/ACKNOWLEDGMENTS
@@ -1,3 +1,3 @@
 ## Acknowledgements
 
-- In order to reduce the bundle size and avoid tree-shaking problems, `hsvToRgb`, `rgbToHex`, `hexToRgb` and `rgbToHsv` methods were copied from [@swiftcarrot/color-fns](https://github.com/swiftcarrot/color-fns) (MIT License).
+- In order to reduce the bundle size and avoid tree-shaking problems, `hsvToRgb`, `rgbToHex` and `hexToRgb` methods were copied from [@swiftcarrot/color-fns](https://github.com/swiftcarrot/color-fns) (MIT License).

--- a/src/packages/hex.js
+++ b/src/packages/hex.js
@@ -6,7 +6,7 @@ import fromHsv from "../utils/hsvToHex";
 import equal from "../utils/equalHex";
 
 const HEX = {
-  defaultColor: "#000",
+  defaultColor: "000",
   toHsv,
   fromHsv,
   equal,

--- a/src/utils/formatClassName.js
+++ b/src/utils/formatClassName.js
@@ -1,3 +1,3 @@
-const formatClassName = (array = []) => array.filter(Boolean).join(" ");
+const formatClassName = (array) => array.filter(Boolean).join(" ");
 
 export default formatClassName;

--- a/src/utils/hexToRgb.js
+++ b/src/utils/hexToRgb.js
@@ -1,7 +1,7 @@
 const hexToRgb = (hex) => {
   if (hex[0] === "#") hex = hex.substr(1);
 
-  if (hex.length === 3) {
+  if (hex.length < 6) {
     return {
       r: parseInt(hex[0] + hex[0], 16),
       g: parseInt(hex[1] + hex[1], 16),

--- a/src/utils/hsvToRgb.js
+++ b/src/utils/hsvToRgb.js
@@ -6,7 +6,7 @@ const hsvToRgb = ({ h, s, v }) => {
   let hh = Math.floor(h),
     b = v * (1 - s),
     c = v * (1 - (h - hh) * s),
-    d = v * (1 - (1 - h - hh) * s),
+    d = v * (1 - (1 - h + hh) * s),
     module = hh % 6;
 
   return {

--- a/src/utils/hsvToRgb.js
+++ b/src/utils/hsvToRgb.js
@@ -3,17 +3,17 @@ const hsvToRgb = ({ h, s, v }) => {
   s = s / 100;
   v = v / 100;
 
-  let i = Math.floor(h),
-    f = h - i,
-    p = v * (1 - s),
-    q = v * (1 - f * s),
-    t = v * (1 - (1 - f) * s),
-    mod = i % 6,
-    r = Math.round([v, q, p, p, t, v][mod] * 255),
-    g = Math.round([t, v, v, q, p, p][mod] * 255),
-    b = Math.round([p, p, t, v, v, q][mod] * 255);
+  let hh = Math.floor(h),
+    b = v * (1 - s),
+    c = v * (1 - (h - hh) * s),
+    d = v * (1 - (1 - h - hh) * s),
+    module = hh % 6;
 
-  return { r, g, b };
+  return {
+    r: Math.round([v, c, b, b, d, v][module] * 255),
+    g: Math.round([d, v, v, c, b, b][module] * 255),
+    b: Math.round([b, b, d, v, v, c][module] * 255),
+  };
 };
 
 export default hsvToRgb;

--- a/src/utils/hsvToRgb.js
+++ b/src/utils/hsvToRgb.js
@@ -1,34 +1,19 @@
 const hsvToRgb = ({ h, s, v }) => {
+  h = (h / 360) * 6;
   s = s / 100;
   v = v / 100;
 
-  let rgb = [];
-  let c = v * s;
-  let hh = h / 60;
-  let x = c * (1 - Math.abs((hh % 2) - 1));
-  let m = v - c;
+  let i = Math.floor(h),
+    f = h - i,
+    p = v * (1 - s),
+    q = v * (1 - f * s),
+    t = v * (1 - (1 - f) * s),
+    mod = i % 6,
+    r = Math.round([v, q, p, p, t, v][mod] * 255),
+    g = Math.round([t, v, v, q, p, p][mod] * 255),
+    b = Math.round([p, p, t, v, v, q][mod] * 255);
 
-  if (hh >= 0 && hh < 1) {
-    rgb = [c, x, 0];
-  } else if (hh >= 1 && hh < 2) {
-    rgb = [x, c, 0];
-  } else if (hh >= 2 && hh < 3) {
-    rgb = [0, c, x];
-  } else if (h >= 3 && hh < 4) {
-    rgb = [0, x, c];
-  } else if (h >= 4 && hh < 5) {
-    rgb = [x, 0, c];
-  } else if (h >= 5 && hh <= 6) {
-    rgb = [c, 0, x];
-  } else {
-    rgb = [0, 0, 0];
-  }
-
-  return {
-    r: Math.round(255 * (rgb[0] + m)),
-    g: Math.round(255 * (rgb[1] + m)),
-    b: Math.round(255 * (rgb[2] + m)),
-  };
+  return { r, g, b };
 };
 
 export default hsvToRgb;

--- a/src/utils/rgbToHex.js
+++ b/src/utils/rgbToHex.js
@@ -1,6 +1,6 @@
 const format = (number) => {
   const hex = number.toString(16);
-  return hex.length === 1 ? "0" + hex : hex;
+  return hex.length < 2 ? "0" + hex : hex;
 };
 
 const rgbToHex = ({ r, g, b }) => "#" + format(r) + format(g) + format(b);

--- a/src/utils/rgbToHsv.js
+++ b/src/utils/rgbToHsv.js
@@ -1,26 +1,20 @@
 const rgbToHsv = ({ r, g, b }) => {
-  let h, s, v;
   let max = Math.max(r, g, b);
-  let min = Math.min(r, g, b);
-  let delta = max - min;
+  let delta = max - Math.min(r, g, b);
 
-  if (delta === 0) {
-    h = 0;
-  } else if (r === max) {
-    h = ((g - b) / delta) % 6;
-  } else if (g === max) {
-    h = (b - r) / delta + 2;
-  } else {
-    h = (r - g) / delta + 4;
-  }
+  let hh = delta
+    ? max === r
+      ? (g - b) / delta
+      : max === g
+      ? 2 + (b - r) / delta
+      : 4 + (r - g) / delta
+    : 0;
 
-  h = Math.round(h * 60);
-  s = Math.round((max === 0 ? 0 : delta / max) * 100);
-  v = Math.round((max / 255) * 100);
-
-  if (h < 0) h += 360;
-
-  return { h, s, v };
+  return {
+    h: Math.round(60 * (hh < 0 ? hh + 6 : hh)),
+    s: Math.round(max ? (delta / max) * 100 : 0),
+    v: Math.round((max / 255) * 100),
+  };
 };
 
 export default rgbToHsv;

--- a/tests/components.test.js
+++ b/tests/components.test.js
@@ -18,6 +18,19 @@ class FakeMouseEvent extends MouseEvent {
   }
 }
 
+// Mock `HTMLElement.getBoundingClientRect` to be able to read element sizes
+// See https://github.com/jsdom/jsdom/issues/135#issuecomment-68191941
+Object.defineProperties(HTMLElement.prototype, {
+  getBoundingClientRect: {
+    get: () => () => ({
+      left: 5,
+      top: 5,
+      width: 100,
+      height: 100,
+    }),
+  },
+});
+
 it("Renders proper HTML", () => {
   const result = render(<ColorPicker color="#F00" />);
 

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -111,7 +111,6 @@ it("Compares two HSV colors", () => {
 });
 
 it("Formats a class name", () => {
-  expect(formatClassName()).toBe("");
   expect(formatClassName(["one"])).toBe("one");
   expect(formatClassName(["one", "two", "three"])).toBe("one two three");
   expect(formatClassName([false, "two", null])).toBe("two");


### PR DESCRIPTION
Rewrote few methods and used small tweaks in order to make the HEX color picker bundle lighter.

### Results:
```
1609 B → 1539 B (–70 B)