### PR TITLE
HexInput component

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,6 @@
     "es6": true
   },
   "parserOptions": {
-    "ecmaVersion": 2018,
     "sourceType": "module"
   },
   "plugins": ["prettier", "react"],

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
     "es6": true
   },
   "parserOptions": {
+    "ecmaVersion": 2018,
     "sourceType": "module"
   },
   "plugins": ["prettier", "react"],

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ dist/
 /hsv
 /rgb
 /rgbString
+/HexInput
 
 # OSX
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -117,6 +117,35 @@ The easiest way to tweak react-colorful is to create another stylesheet to overr
 
 [See examples →](https://codesandbox.io/s/react-colorful-customization-demo-mq85z?file=/src/styles.css)
 
+## How to paste or type a color?
+
+**react-colorful**'s color picker itself doesn't include any input field, but don't worry if you need one. Since `v2.1` we provide a separate component that works perfectly in pair with our color picker.
+
+<details>
+  <summary>How to use `HexInput`</summary>
+
+```diff
+import ColorPicker from "react-colorful";
++import HexInput from "react-colorful/HexInput";
+import "react-colorful/dist/index.css";
+
+const YourComponent = () => {
+  const [color, setColor] = useState("#aabbcc");
+  return (
+    <div>
+      <ColorPicker color={color} onChange={setColor} />
++     <HexInput color={color} onChange={setColor} />
+    </div>
+  );
+};
+```
+
+`HexInput` doesn't have any default styles, but accepts all properties that a regular `input` tag does (such as `className`, `placeholder` and `autoFocus`). That means you can place and modify this component as you like. Also, that allows you to combine the color picker and input in different ways.
+
+By the way, `HexInput` is also minimalist-friendly — only 500 bytes gzipped.
+
+</details>
+
 ## Why react-colorful?
 
 Today each dependency drags more dependencies and increases your project’s bundle size uncontrollably. But size is very important for everything that intends to work in a browser.
@@ -149,5 +178,5 @@ To show you the problem that **react-colorful** is trying to solve, we have perf
 ## Roadmap
 
 - [x] Additional modules to support different color models (like HSL and RGB)
-- [ ] HEX input component
+- [x] HEX input component
 - [ ] Preact support

--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ The easiest way to tweak react-colorful is to create another stylesheet to overr
 
 ## How to paste or type a color?
 
-**react-colorful**'s color picker itself doesn't include any input field, but don't worry if you need one. Since `v2.1` we provide a separate component that works perfectly in pair with our color picker.
+As you probably noticed the color picker itself doesn't include an input field, but don't worry if you need one. **react-colorful** is a modular library that allows you to build any picker you need. Since `v2.1` we provide an additional component that works perfectly in pair with our color picker.
 
 <details>
-  <summary>How to use `HexInput`</summary>
+  <summary>How to use <code>HexInput</code></summary>
 
 ```diff
 import ColorPicker from "react-colorful";

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Today each dependency drags more dependencies and increases your project’s bun
 
 - has no dependencies (no risks in terms of vulnerabilities, no unexpected bundle size changes);
 - built with hooks and functional components only (no classes and polyfills for them);
-- a lot of things that you probably don't need (like 8-digit HEX colors support) were stripped out.
+- ships only a minimal amount of manually optimized color conversion algorithms (while most of the popular pickers import entire color manipulation libraries that increase the bundle size by more than 10 KB and make your app slower).
 
 To show you the problem that **react-colorful** is trying to solve, we have performed a simple benchmark (using [size-limit](https://github.com/ai/size-limit)) against popular React color picker libraries:
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ const YourComponent = () => {
 
 `HexInput` doesn't have any default styles, but accepts all properties that a regular `input` tag does (such as `className`, `placeholder` and `autoFocus`). That means you can place and modify this component as you like. Also, that allows you to combine the color picker and input in different ways.
 
-By the way, `HexInput` is also minimalist-friendly — only 500 bytes gzipped.
+By the way, `HexInput` is also minimalist-friendly — only 400 bytes gzipped.
 
 </details>
 

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -9,7 +9,7 @@
       name="viewport"
     />
     <link
-      href="https://fonts.googleapis.com/css2?family=Recursive&family=Source+Sans+Pro&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Recursive&family=PT+Mono&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from "react";
 import ReactDOM from "react-dom";
 import ColorPicker from "../../src";
+import HexInput from "../../src/components/HexInput";
 import hexToRgb from "../../src/utils/hexToRgb";
 import styles from "./styles.css";
 import useFaviconColor from "./hooks/useFaviconColor";
@@ -29,7 +30,12 @@ const Demo = () => {
   return (
     <div className={styles.wrapper} style={{ color: textColor }}>
       <header className={styles.header}>
-        <ColorPicker className={styles.colorPicker} color={color} onChange={handleChange} />
+        <div className={styles.demo}>
+          <ColorPicker className={styles.colorPicker} color={color} onChange={handleChange} />
+          <div className={styles.field}>
+            <HexInput className={styles.hexInput} color={color} onChange={handleChange} />
+          </div>
+        </div>
         <div className={styles.headerContent}>
           <h1 className={styles.headerTitle}>React Colorful 🎨</h1>
           <h2 className={styles.headerDescription}>

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -53,7 +53,6 @@ body {
   padding-left: 0.7em;
   background: none;
   outline: none;
-  font-variant-numeric: tabular-nums;
   text-transform: uppercase;
   opacity: 0.5;
   transition: opacity 0.2s;

--- a/demo/src/styles.css
+++ b/demo/src/styles.css
@@ -17,10 +17,51 @@ body {
   transition: color 0.15s;
 }
 
-.colorPicker {
+.demo {
+  position: relative;
+  width: 200px;
   flex-shrink: 0;
+}
+
+.colorPicker {
+  width: 100%;
   border-radius: 9px;
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.2);
+}
+
+.field {
+  position: absolute;
+  top: calc(100% + 16px);
+  left: calc(50% - 45px);
+  width: 90px;
+  font-family: "PT Mono", monospace;
+}
+
+.field:before {
+  content: "#";
+  position: absolute;
+  top: 0;
+  left: 0;
+  pointer-events: none;
+  opacity: 0.33;
+}
+
+.hexInput {
+  display: block;
+  color: inherit;
+  width: 100%;
+  padding-left: 0.7em;
+  background: none;
+  outline: none;
+  font-variant-numeric: tabular-nums;
+  text-transform: uppercase;
+  opacity: 0.5;
+  transition: opacity 0.2s;
+}
+
+.hexInput:focus,
+.hexInput:hover {
+  opacity: 1;
 }
 
 .header {
@@ -84,5 +125,9 @@ body {
   .headerDescription {
     margin-left: auto;
     margin-right: auto;
+  }
+
+  .field {
+    display: none;
   }
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "hslString",
     "hsv",
     "rgb",
-    "rgbString"
+    "rgbString",
+    "HexInput"
   ],
   "repository": "omgovich/react-colorful",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -41,6 +41,10 @@
     {
       "path": "hsv/index.js",
       "limit": "2 KB"
+    },
+    {
+      "path": "HexInput/index.module.js",
+      "limit": "1 KB"
     }
   ],
   "jest": {

--- a/src/components/HexInput.js
+++ b/src/components/HexInput.js
@@ -33,6 +33,7 @@ const HexInput = (props) => {
 
   // Spread operator replacement to get rid of the polyfill (saves 150 bytes gzipped)
   const inputProps = Object.assign({}, props, {
+    color: null, // do not add `color` attr to `input`-tag
     value,
     maxLength: 6,
     spellCheck: "false", // the element should not be checked for spelling errors

--- a/src/components/HexInput.js
+++ b/src/components/HexInput.js
@@ -1,0 +1,45 @@
+import React, { useState, useEffect, useCallback } from "react";
+import validHex from "../utils/validHex";
+
+const escape = (hex) => hex.replace(/([^0-9A-F]+)/gi, "");
+
+const HexInput = ({ color, onChange, ...rest }) => {
+  const [value, setValue] = useState(escape(color));
+
+  const handleChange = useCallback(
+    (e) => {
+      const inputValue = escape(e.target.value);
+      setValue(inputValue);
+      if (onChange && validHex(inputValue)) onChange("#" + inputValue);
+    },
+    [onChange]
+  );
+
+  const handleBlur = useCallback(
+    (e) => {
+      if (!validHex(e.target.value)) setValue(escape(color));
+    },
+    [color]
+  );
+
+  useEffect(() => {
+    setValue(escape(color));
+  }, [color]);
+
+  return (
+    <input
+      {...rest}
+      value={value}
+      maxLength={6}
+      spellCheck="false"
+      onChange={handleChange}
+      onBlur={handleBlur}
+    />
+  );
+};
+
+HexInput.defaultProps = {
+  color: "",
+};
+
+export default React.memo(HexInput);

--- a/src/components/HexInput.js
+++ b/src/components/HexInput.js
@@ -4,7 +4,8 @@ import validHex from "../utils/validHex";
 // Escapes all non-hexadecimal characters including "#"
 const escape = (hex) => hex.replace(/([^0-9A-F]+)/gi, "");
 
-const HexInput = ({ color, onChange, ...rest }) => {
+const HexInput = (props) => {
+  const { color, onChange } = props;
   const [value, setValue] = useState(escape(color));
 
   // Trigger `onChange` handler only if the input value is a valid HEX-color
@@ -30,16 +31,16 @@ const HexInput = ({ color, onChange, ...rest }) => {
     setValue(escape(color));
   }, [color]);
 
-  return (
-    <input
-      {...rest}
-      value={value}
-      maxLength={6}
-      spellCheck="false"
-      onChange={handleChange}
-      onBlur={handleBlur}
-    />
-  );
+  // Spread operator replacement to get rid of the polyfill (saves 150 bytes gzipped)
+  const inputProps = Object.assign({}, props, {
+    value,
+    maxLength: 6,
+    spellCheck: "false", // the element should not be checked for spelling errors
+    onChange: handleChange,
+    onBlur: handleBlur,
+  });
+
+  return React.createElement("input", inputProps);
 };
 
 HexInput.defaultProps = {

--- a/src/components/HexInput.js
+++ b/src/components/HexInput.js
@@ -1,11 +1,13 @@
 import React, { useState, useEffect, useCallback } from "react";
 import validHex from "../utils/validHex";
 
+// Escapes all non-hexadecimal characters including "#"
 const escape = (hex) => hex.replace(/([^0-9A-F]+)/gi, "");
 
 const HexInput = ({ color, onChange, ...rest }) => {
   const [value, setValue] = useState(escape(color));
 
+  // Trigger `onChange` handler only if the input value is a valid HEX-color
   const handleChange = useCallback(
     (e) => {
       const inputValue = escape(e.target.value);
@@ -15,6 +17,7 @@ const HexInput = ({ color, onChange, ...rest }) => {
     [onChange]
   );
 
+  // Take the color from props if the last typed color (in local state) is not valid
   const handleBlur = useCallback(
     (e) => {
       if (!validHex(e.target.value)) setValue(escape(color));
@@ -22,6 +25,7 @@ const HexInput = ({ color, onChange, ...rest }) => {
     [color]
   );
 
+  // Update the local state when `color` property value is changed
   useEffect(() => {
     setValue(escape(color));
   }, [color]);

--- a/src/packages/HexInput.js
+++ b/src/packages/HexInput.js
@@ -1,0 +1,2 @@
+import HexInput from "../components/HexInput";
+export default HexInput;

--- a/src/utils/validHex.js
+++ b/src/utils/validHex.js
@@ -1,0 +1,6 @@
+const hex3 = /^#?[0-9A-F]{3}$/i;
+const hex6 = /^#?[0-9A-F]{6}$/i;
+
+const validHex = (color) => hex6.test(color) || hex3.test(color);
+
+export default validHex;

--- a/tests/__snapshots__/components.test.js.snap
+++ b/tests/__snapshots__/components.test.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Renders \`HexInput\` component 1`] = `
+<input
+  maxlength="6"
+  spellcheck="false"
+  value="F00"
+/>
+`;
+
 exports[`Renders proper HTML 1`] = `
 <div
   class="react-colorful container"

--- a/tests/__snapshots__/components.test.js.snap
+++ b/tests/__snapshots__/components.test.js.snap
@@ -1,8 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Renders \`HexInput\` component 1`] = `
+exports[`Renders \`HexInput\` component properly 1`] = `
 <input
+  class="custom-input"
   maxlength="6"
+  placeholder="AABBCC"
   spellcheck="false"
   value="F00"
 />

--- a/tests/components.test.js
+++ b/tests/components.test.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { render, cleanup, fireEvent, waitFor } from "@testing-library/react";
 import ColorPicker from "../src/";
+import HexInput from "../src/packages/HexInput";
 
 afterEach(cleanup);
 
@@ -77,4 +78,20 @@ it("Triggers `onChange` after a touch interaction", async () => {
   fireEvent.touchMove(hue, { touches: [{ pageX: 100, pageY: 0, bubbles: true }] });
 
   expect(handleChange).toHaveReturned();
+});
+
+it("Renders `HexInput` component", () => {
+  const result = render(<HexInput color="#F00" />);
+
+  expect(result.container.firstChild).toMatchSnapshot();
+});
+
+it("Fires `onChange` when user changes `HexInput` value", () => {
+  const handleChange = jest.fn((hex) => hex);
+  const result = render(<HexInput onChange={handleChange} />);
+  const input = result.container.firstChild;
+
+  fireEvent.change(input, { target: { value: "112233" } });
+
+  expect(handleChange).toHaveReturnedWith("#112233");
 });

--- a/tests/components.test.js
+++ b/tests/components.test.js
@@ -80,8 +80,8 @@ it("Triggers `onChange` after a touch interaction", async () => {
   expect(handleChange).toHaveReturned();
 });
 
-it("Renders `HexInput` component", () => {
-  const result = render(<HexInput color="#F00" />);
+it("Renders `HexInput` component properly", () => {
+  const result = render(<HexInput className="custom-input" color="#F00" placeholder="AABBCC" />);
 
   expect(result.container.firstChild).toMatchSnapshot();
 });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -2,6 +2,7 @@
 import hexToHsv from "../src/utils/hexToHsv";
 import hsvToHex from "../src/utils/hsvToHex";
 import equalHex from "../src/utils/equalHex";
+import validHex from "../src/utils/validHex";
 // HSL
 import hsvToHsl from "../src/utils/hsvToHsl";
 import hslToHsv from "../src/utils/hslToHsv";
@@ -108,6 +109,23 @@ it("Compares two HSV colors", () => {
   expect(equalColorObjects({ h: 100, s: 50, v: 50 }, { h: 100, s: 50, v: 50 })).toBe(true);
   expect(equalColorObjects({ h: 50, s: 0, v: 0 }, { h: 100, s: 0, v: 0 })).toBe(false);
   expect(equalColorObjects({ h: 1, s: 2, v: 3 }, { h: 4, s: 5, v: 6 })).toBe(false);
+});
+
+it("Validates HEX colors", () => {
+  // valid strings
+  expect(validHex("#8c0dba")).toBe(true);
+  expect(validHex("aabbcc")).toBe(true);
+  expect(validHex("#ABC")).toBe(true);
+  expect(validHex("123")).toBe(true);
+  // out of [0-F] range
+  expect(validHex("#eeffhh")).toBe(false);
+  // wrong length
+  expect(validHex("#12")).toBe(false);
+  expect(validHex("#12345")).toBe(false);
+  // empty
+  expect(validHex("")).toBe(false);
+  expect(validHex(null)).toBe(false);
+  expect(validHex()).toBe(false);
 });
 
 it("Formats a class name", () => {


### PR DESCRIPTION
In case if the user needs to have a text field to type/paste HEX-color, he could import additional `HexInput` component which works well in pair with the picker and costs just 400 bytes:
```js
import ColorPicker from "react-colorful";
import HexInput from 'react-colorful/HexInput';

const YourComponent = () => {
  const [color, setColor] = useState("#aabbcc");
  return (
    <div>
      <ColorPicker color={color} onChange={setColor} />
      <HexInput color={color} onChange={setColor} />
    </div>
  );
};
```

This component doesn't have any default styles. It's just an input with proper behavior. The developers could place and tweak this component any way they want.

BTW I noticed that ~33% of the `HexInput`'s bundle size was the spread operator polyfill, so I used `React.createElement("input", Object.assign({}, props, extraProps))` to fix that. 

### How to test 

`npm run start-demo`