### PR TITLE
fix(types): Correcting all props to be optional

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,44 +1,44 @@
 declare module "react-colorful" {
   import { FC } from "react";
-  const ColorPicker: FC<{ className: string; color: string; onChange: (newColor: string) => void }>;
+  const ColorPicker: FC<{ className?: string; color?: string; onChange?: (newColor: string) => void }>;
   export = ColorPicker;
 }
 
 declare module "react-colorful/rgb" {
   import { FC } from "react";
   type rgb = { r: number; g: number; b: number };
-  const ColorPicker: FC<{ className: string; color: rgb; onChange: (newColor: rgb) => void }>;
+  const ColorPicker: FC<{ className?: string; color?: rgb; onChange?: (newColor: rgb) => void }>;
   export = ColorPicker;
 }
 
 declare module "react-colorful/rgbString" {
   import { FC } from "react";
-  const ColorPicker: FC<{ className: string; color: string; onChange: (newColor: string) => void }>;
+  const ColorPicker: FC<{ className?: string; color?: string; onChange?: (newColor: string) => void }>;
   export = ColorPicker;
 }
 
 declare module "react-colorful/hsl" {
   import { FC } from "react";
   type hsl = { h: number; s: number; l: number };
-  const ColorPicker: FC<{ className: string; color: hsl; onChange: (newColor: hsl) => void }>;
+  const ColorPicker: FC<{ className?: string; color?: hsl; onChange?: (newColor: hsl) => void }>;
   export = ColorPicker;
 }
 
 declare module "react-colorful/hslString" {
   import { FC } from "react";
-  const ColorPicker: FC<{ className: string; color: string; onChange: (newColor: string) => void }>;
+  const ColorPicker: FC<{ className?: string; color?: string; onChange?: (newColor: string) => void }>;
   export = ColorPicker;
 }
 
 declare module "react-colorful/hsv" {
   import { FC } from "react";
   type hsv = { h: number; s: number; v: number };
-  const ColorPicker: FC<{ className: string; color: hsv; onChange: (newColor: hsv) => void }>;
+  const ColorPicker: FC<{ className?: string; color?: hsv; onChange?: (newColor: hsv) => void }>;
   export = ColorPicker;
 }
 
 declare module "react-colorful/HexInput" {
   import { FC } from "react";
-  const HexInput: FC<{ color: string; onChange: (newColor: string) => void }>;
+  const HexInput: FC<{ color?: string; onChange?: (newColor: string) => void }>;
   export = HexInput;
 }


### PR DESCRIPTION
I didn't catch that all props were intended to be optional. Apologies, I think I've spent too much time reading TypeScript, where optionals and the like are made super clear at a glance.

Currently the behavior is that TS will expect all props to be provided. Failing to say add the `className` prop results in:

```
Element HexColorPicker doesn't have required attribute className 
```

This will resolve that. All props will be optional.