### PR TITLE
ci(actions): Adding compressed-size-action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+name: Compressed Size
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: preactjs/compressed-size-action@v2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: preactjs/compressed-size-action@v2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          pattern: "**/dist/**/{index.module.js,index.css}"
+          pattern: "{**/dist/**/index.module.js,./dist/index.css}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,3 +12,4 @@ jobs:
       - uses: preactjs/compressed-size-action@v2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          pattern: "**/dist/**/{index.module.js,index.css}"


### PR DESCRIPTION
Compressed Size Action is a GitHub action that reports changes in the compressed file sizes in PRs. [Source Page](https://github.com/preactjs/compressed-size-action). This will allow you to see, at a glance, whether a PR increases or decreases your bundle size, and by how much. Incredibly useful for a library watching its size like this one. It would catch [regressions like this](https://github.com/omgovich/react-colorful/pull/23#issuecomment-680262792) that would normally require manually checking/comparing of numbers.

As of now, this only runs on a PR, but it is also in the works to support push events. 

Having ran a [quick test here](https://github.com/RyanChristian4427/react-colorful/pull/1) it seems that this may only pick up on changes in a `dist` directory. Will figure out the root of that issue but that can/should(?) be fixed in another PR anyhow. So for now this will only work on the main output (hex).

I don't want to directly link as that will ping them, but pull request #2701 over at [Preact](https://github.com/preactjs/preact) shows exactly what we'll be seeing and I think that will be super applicable for this library. It's an open PR, just a couple down from the top of the list. Sorry if there's a way to link without pinging them but I don't know how to do that. 

Edit: Sure enough, moving `rgb/index.js` and the lot to `rgb/dist/index.js` works like a charm.