### PR TITLE
feat: Color object types as named exports

### DIFF
--- a/src/hsl.tsx
+++ b/src/hsl.tsx
@@ -17,3 +17,4 @@ const HslColorPicker = (props: Partial<ColorPickerBaseProps<HSL>>): JSX.Element 
 );
 
 export default HslColorPicker;
+export { HSL };

--- a/src/hsv.tsx
+++ b/src/hsv.tsx
@@ -16,3 +16,4 @@ const HsvColorPicker = (props: Partial<ColorPickerBaseProps<HSV>>): JSX.Element 
 );
 
 export default HsvColorPicker;
+export { HSV };

--- a/src/rgb.tsx
+++ b/src/rgb.tsx
@@ -17,3 +17,4 @@ const RgbColorPicker = (props: Partial<ColorPickerBaseProps<RGB>>): JSX.Element 
 );
 
 export default RgbColorPicker;
+export { RGB };

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,21 +2,18 @@ export interface RGB {
   r: number;
   g: number;
   b: number;
-  [key: string]: number;
 }
 
 export interface HSL {
   h: number;
   s: number;
   l: number;
-  [key: string]: number;
 }
 
 export interface HSV {
   h: number;
   s: number;
   v: number;
-  [key: string]: number;
 }
 
 export type AnyColor = string | HSL | HSV | RGB;

--- a/src/utils/compare.ts
+++ b/src/utils/compare.ts
@@ -2,15 +2,19 @@ import { hexToRgb } from "./convert";
 
 import { HSL, HSV, RGB } from "../types";
 
-interface ColorCompare {
-  [key: string]: number;
-}
-
 export const equalColorObjects = (first: HSL | HSV | RGB, second: HSL | HSV | RGB): boolean => {
   if (first === second) return true;
 
   for (const prop in first) {
-    if (((first as unknown) as ColorCompare)[prop] !== ((second as unknown) as ColorCompare)[prop])
+    // The following allows for a type-safe calling of this function (first & second have to be HSL, HSV, or RGB)
+    // with type-unsafe iterating over object keys. TS does not allow this without an index (`[key: string]: number`)
+    // on an object to define how iteration is normally done. To ensure extra keys are not allowed on our types,
+    // we must cast our object to unknown (as RGB demands `r` be a key, while `Record<string, x>` does not care if
+    // there is or not), and then as a type TS can iterate over.
+    if (
+      ((first as unknown) as Record<string, number>)[prop] !==
+      ((second as unknown) as Record<string, number>)[prop]
+    )
       return false;
   }
 

--- a/src/utils/compare.ts
+++ b/src/utils/compare.ts
@@ -2,11 +2,16 @@ import { hexToRgb } from "./convert";
 
 import { HSL, HSV, RGB } from "../types";
 
+interface ColorCompare {
+  [key: string]: number;
+}
+
 export const equalColorObjects = (first: HSL | HSV | RGB, second: HSL | HSV | RGB): boolean => {
   if (first === second) return true;
 
   for (const prop in first) {
-    if (first[prop] !== second[prop]) return false;
+    if (((first as unknown) as ColorCompare)[prop] !== ((second as unknown) as ColorCompare)[prop])
+      return false;
   }
 
   return true;


### PR DESCRIPTION
PR is in response to [this comment](https://github.com/omgovich/react-colorful/pull/23#issuecomment-683318037).

This adds HSL, HSV, and RGB as named exports for their respective color pickers, resulting in the following API:

```
import HslColorPicker, { HSL } from 'react-colorful/hsl';
```

This is a major improvement in accessibility over the previous solution:

```
import HslColorPicker from 'react-colorful/hsl';
import { HSL } from 'react-colorful/dist/types';
```

Only a single import statement required.

I also changed our types a bit to remove the indexing on the objects outside of the color object comparator scope. The color object comparator is a bit more verbose and more complicated with its casts but it's an improvement, especially with the types now being exported.