### PR TITLE
TS: Allow to pass another props to HexInput

### DIFF
--- a/src/components/HexInput.tsx
+++ b/src/components/HexInput.tsx
@@ -5,10 +5,9 @@ import { validHex } from "../utils/validate";
 // Escapes all non-hexadecimal characters including "#"
 const escape = (hex: string) => hex.replace(/([^0-9A-F]+)/gi, "");
 
-interface Props {
+interface Props extends HTMLInputElement {
   color: string;
   onChange: (newColor: string) => void;
-  [key: string]: unknown;
 }
 
 const HexInput = (props: Partial<Props>) => {

--- a/src/components/HexInput.tsx
+++ b/src/components/HexInput.tsx
@@ -8,6 +8,7 @@ const escape = (hex: string) => hex.replace(/([^0-9A-F]+)/gi, "");
 interface Props {
   color: string;
   onChange: (newColor: string) => void;
+  [key: string]: unknown;
 }
 
 const HexInput = (props: Partial<Props>) => {


### PR DESCRIPTION
@RyanChristian4427 I just noticed that it's not allowed to pass the default input tag props (such as `className`, `placeholder`, etc) to `HexInput` component.