### PR TITLE
docs(readme): Added Preact section

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ Take a look at [Supported Color Models](#supported-color-models) for more inform
 
 </details>
 
+## Preact Support
+
+**react-colorful** will work flawlessly with Preact out-of-the-box if you're using [Preact-CLI](https://github.com/preactjs/preact-cli), [NextJS with Preact](https://github.com/vercel/next.js/tree/canary/examples/using-preact), or a few other tools/boilerplates thanks to aliasing.
+
+If you're using another solution, please refer to the [Aliasing React to Preact](https://preactjs.com/guide/v10/getting-started#aliasing-react-to-preact) section of the Preact documentation.
+
 ## Why react-colorful?
 
 Today each dependency drags more dependencies and increases your project’s bundle size uncontrollably. But size is very important for everything that intends to work in a browser.
@@ -205,4 +211,3 @@ To show you the problem that **react-colorful** is trying to solve, we have perf
 - [x] TypeScript support
 - [x] Rewrite the codebase to TypeScript
 - [ ] Alpha channel support (RGBA and HSLA color models)
-- [ ] Preact support

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Take a look at [Supported Color Models](#supported-color-models) for more inform
 
 </details>
 
-## Preact Support
+## Usage with Preact
 
 **react-colorful** will work flawlessly with Preact out-of-the-box if you're using [Preact-CLI](https://github.com/preactjs/preact-cli), [NextJS with Preact](https://github.com/vercel/next.js/tree/canary/examples/using-preact), or a few other tools/boilerplates thanks to aliasing.
 


### PR DESCRIPTION
Adding documentation for usage with Preact.

Added a few links for common Preact starting points that will work right out of the box along with documentation on how to use when not using one of those starting points.

I removed "Preact Support" from the roadmap and labeled the Preact section as "Usage with Preact" because it's rather incorrect to say this library supports Preact in any way. It has been the Preact team's work through `preact/compat` that ensures most React libraries (this one included) will work flawlessly in a Preact application. Saying that we support it therefore feels a bit disingenuous as we really didn't do anything ourselves.