### PR TITLE
Refactor/misc

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "size": "npm run build && size-limit",
     "test": "jest tests",
     "build": "del-cli 'dist/*' && microbundle build --entry src/index.ts --jsx React.createElement --name react-colorful --css-modules true --tsconfig tsconfig.build.json",
-    "check-types": "tsc",
+    "check-types": "tsc --noEmit true",
     "prepublishOnly": "npm run build",
     "start-demo": "parcel demo/src/index.html --out-dir demo/dist --open",
     "build-demo": "del-cli 'demo/dist/*' && parcel build demo/src/index.html --out-dir demo/dist --public-url /react-colorful/",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint src/**/*.{ts,tsx} demo/src/**/*.{ts,tsx}",
     "size": "npm run build && size-limit",
     "test": "jest tests",
-    "build": "microbundle build --entry src/index.ts --jsx React.createElement --name react-colorful --css-modules true --tsconfig tsconfig.build.json",
+    "build": "del-cli 'dist/*' && microbundle build --entry src/index.ts --jsx React.createElement --name react-colorful --css-modules true --tsconfig tsconfig.build.json",
     "prepublishOnly": "npm run build",
     "start-demo": "parcel demo/src/index.html --out-dir demo/dist --open",
     "build-demo": "del-cli 'demo/dist/*' && parcel build demo/src/index.html --out-dir demo/dist --public-url /react-colorful/",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "size": "npm run build && size-limit",
     "test": "jest tests",
     "build": "del-cli 'dist/*' && microbundle build --entry src/index.ts --jsx React.createElement --name react-colorful --css-modules true --tsconfig tsconfig.build.json",
+    "check-types": "tsc",
     "prepublishOnly": "npm run build",
     "start-demo": "parcel demo/src/index.html --out-dir demo/dist --open",
     "build-demo": "del-cli 'demo/dist/*' && parcel build demo/src/index.html --out-dir demo/dist --public-url /react-colorful/",

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,7 +27,7 @@ export interface ColorModel<T extends AnyColor> {
   equal: (first: T, second: T) => boolean;
 }
 
-export interface ColorPickerBaseProps<T> {
+export interface ColorPickerBaseProps<T extends AnyColor> {
   className: string;
   color: T;
   onChange: (newColor: T) => void;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "jsxFactory": "React.createElement",
     "moduleResolution": "node",
     "noImplicitAny": true,
-    "outDir": "dist",
     "declaration": true,
     "strict": true,
     "noEmit": true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "noImplicitAny": true,
     "outDir": "dist",
     "declaration": true,
-    "strict": true
+    "strict": true,
+    "noEmit": true
   },
   "include": ["src", "test", "demo/src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,8 +7,7 @@
     "jsxFactory": "React.createElement",
     "moduleResolution": "node",
     "declaration": true,
-    "strict": true,
-    "noEmit": true
+    "strict": true
   },
   "include": ["src", "test", "demo/src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "jsx": "react",
     "jsxFactory": "React.createElement",
     "moduleResolution": "node",
-    "noImplicitAny": true,
     "declaration": true,
     "strict": true,
     "noEmit": true


### PR DESCRIPTION
Just a couple of minor internal changes.

## Changes

- Added `del-cli` to our build command. Goes back to what we had in the build script.
- Correcting `ColorPickerBaseProps` type. It (incorrectly) did not extend `AnyColor`.
  - While it was very unlikely to ever cause an issue due to `ColorModel` constraining it, this can and should be tightened down further.
- Added `"noEmit": true` to our `tsconfig.json`. As we already use `microbundle` for all of our building, `tsc` doesn't really serve a purpose. However, if we enable `noEmit` then `tsc` can be used as a typechecker, which is quite useful. 
  - Use `yarn tsc` to check all types in the app without the production-level bundling. Much quicker when types are all that you want to check.