### PR TITLE
Fix: Fast Tap and Release in iOS Safari

### DIFF
--- a/src/components/common/Interactive.tsx
+++ b/src/components/common/Interactive.tsx
@@ -1,22 +1,12 @@
 import React, { useState, useLayoutEffect, useRef, useCallback } from "react";
 import styles from "../../css/styles.css";
 
-let hasTouched = false;
-
 // Limit number within [0, 1] bounds.
 // Use ternary operator instead of `Math.min(Math.max(0, number), 1)` to save few bytes
 const limit = (number: number) => (number > 1 ? 1 : number < 0 ? 0 : number);
 
 // Check if an event was triggered by touch
 const isTouch = (e: MouseEvent | TouchEvent) => window.TouchEvent && e instanceof TouchEvent;
-
-// Prevent mobile browsers from handling mouse events (conflicting with touch ones).
-// If we detected a touch interaction before, we prefer reacting to touch events only.
-const isValid = (event: MouseEvent | TouchEvent): boolean => {
-  if (hasTouched && !isTouch(event)) return false;
-  if (!hasTouched) hasTouched = isTouch(event);
-  return true;
-};
 
 export interface Interaction {
   left: number;
@@ -30,6 +20,7 @@ interface Props {
 
 const InteractiveBase = ({ onMove, children }: Props) => {
   const container = useRef<HTMLDivElement>(null);
+  const hasTouched = useRef(false);
   const [isDragging, setDragging] = useState(false);
 
   const getRelativePosition = useCallback((event: MouseEvent | TouchEvent) => {
@@ -45,6 +36,14 @@ const InteractiveBase = ({ onMove, children }: Props) => {
       top: limit((pointer.pageY - (rect.top + window.pageYOffset)) / rect.height),
     };
   }, []);
+
+  // Prevent mobile browsers from handling mouse events (conflicting with touch ones).
+  // If we detected a touch interaction before, we prefer reacting to touch events only.
+  const isValid = (event: MouseEvent | TouchEvent): boolean => {
+    if (hasTouched.current && !isTouch(event)) return false;
+    if (!hasTouched.current) hasTouched.current = isTouch(event);
+    return true;
+  };
 
   const handleMove = useCallback(
     (event: MouseEvent | TouchEvent) => {
@@ -72,8 +71,8 @@ const InteractiveBase = ({ onMove, children }: Props) => {
     (state) => {
       // add or remove additional pointer event listeners
       const toggleEvent = state ? window.addEventListener : window.removeEventListener;
-      toggleEvent(hasTouched ? "touchmove" : "mousemove", handleMove);
-      toggleEvent(hasTouched ? "touchend" : "mouseup", handleMoveEnd);
+      toggleEvent(hasTouched.current ? "touchmove" : "mousemove", handleMove);
+      toggleEvent(hasTouched.current ? "touchend" : "mouseup", handleMoveEnd);
     },
     [handleMove, handleMoveEnd]
   );

--- a/tests/components.test.js
+++ b/tests/components.test.js
@@ -119,6 +119,24 @@ it("Changes alpha channel value after an interaction", async () => {
   expect(handleChange).toHaveReturnedWith({ h: 100, s: 0, l: 0, a: 1 });
 });
 
+// Fast clicks on mobile devices
+// See https://github.com/omgovich/react-colorful/issues/55
+it("Doesn't react on mouse events after a touch interaction", () => {
+  const handleChange = jest.fn((hex) => hex);
+  const result = render(<HexColorPicker color="00f" onChange={handleChange} />);
+  const hue = result.container.querySelector(".react-colorful__hue .interactive");
+
+  fireEvent.touchStart(hue, { touches: [{ pageX: 0, pageY: 0, bubbles: true }] }); // 1 (#ff0000)
+  fireEvent.touchMove(hue, { touches: [{ pageX: 55, pageY: 0, bubbles: true }] }); // 2 (#00ffff)
+
+  // Should be skipped
+  fireEvent(hue, new FakeMouseEvent("mousedown", { pageX: 35, pageY: 0, bubbles: true })); // 3
+  fireEvent(hue, new FakeMouseEvent("mousemove", { pageX: 105, pageY: 0, bubbles: true })); // 4
+
+  expect(handleChange).toHaveReturnedTimes(2);
+  expect(handleChange).toHaveReturnedWith("#00ffff");
+});
+
 it("Renders `HexColorInput` component properly", () => {
   const result = render(
     <HexColorInput className="custom-input" color="#F00" placeholder="AABBCC" />


### PR DESCRIPTION
Fixes #55

The problem happens because sometimes iOS Safari calls `mousedown` and `mouseup` right after short touch interactions.
It seems to me that the browser thinks that it was a click (a combination of `mousedown` and `mouseup`) so it handles these events as well.