### PR TITLE
Refactor/built types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,15 +14,6 @@ node_modules/
 .cache
 dist/
 
-# packages
-/hex
-/hsl
-/hslString
-/hsv
-/rgb
-/rgbString
-/HexInput
-
 # OSX
 .DS_Store
 .LSOverride

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,10 @@
+# blacklist all
+**
+
+# include whitelist
+!dist/*
+!dist/components/*
+!LICENSE
+!ACKNOWLEDGMENTS
+!README.md
+!package.json

--- a/package.json
+++ b/package.json
@@ -104,12 +104,6 @@
       "\\.css$": "identity-obj-proxy"
     }
   },
-  "files": [
-    "ACKNOWLEDGMENTS",
-    "LICENSE",
-    "README.md",
-    "dist"
-  ],
   "repository": "omgovich/react-colorful",
   "keywords": [
     "react",


### PR DESCRIPTION
### Changes

This PR removes 12 `.d.ts` files that are internal types and not exposed to the end users. This brings the total number of files in the package from 41 down to 29. 

I moved this to a `.npmignore` file as I couldn't get the `files` field to cooperate with wildcards. Not entirely sure what was going on there, as the docs say it should be supported, but I figure this is a fine solution. Having a dedicated file for what is included and excluded in the bundle could be convenient. 