### PR TITLE
docs(readme): Expounding upon Preact + TS set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,31 @@ Take a look at [Supported Color Models](#supported-color-models) for more inform
 
 If you are using another solution, please refer to the [Aliasing React to Preact](https://preactjs.com/guide/v10/getting-started#aliasing-react-to-preact) section of the Preact documentation.
 
+<details>
+  <summary>Preact + Typescript</summary><br />
+
+**react-colorful**, like all other React + TS projects, can potentially cause issues in a Preact + TS application if you have the `@types/react` package installed, either as a direct dependency or a dependency of a dependency. For example, the Preact TS template comes with `@types/enzyme` which has `@types/react` as a dependency.
+
+To fix this, create a `declaration.d.ts` file or add to your existing:
+
+```
+import React from "react";
+
+declare global {
+    namespace React {
+        interface ReactElement {
+            nodeName: any;
+            attributes: any;
+            children: any;
+        }
+    }
+}
+```
+
+This will correct the types an allow you to use **react-colorful** along with many other React + TS libraries in your Preact + TS application.
+
+</details>
+
 ## Why react-colorful?
 
 Today each dependency drags more dependencies and increases your project’s bundle size uncontrollably. But size is very important for everything that intends to work in a browser.


### PR DESCRIPTION
Would close #39 

This PR adds a subsection to the Preact section of the ReadMe that describes a potential problem that can arise with a Preact TS application and this library (or any React component library that uses `@types/react` for that matter). 

As the [Preact TypeScript template](https://github.com/preactjs-templates/typescript) will throw this error right out-of-the-box I feel that it is important to note, even if not an issue that this library can solve.

As a heavy user of Preact, I love when a library author acknowledges Preact users and notes any potential changes that will need to be made. I figure we can do the same here especially as this is quite an easy fix.

I'm not entirely sure that I love the wording right now, might come back later and make some adjustments or rewrite completely. 

## Changes
* Add documentation for Preact + TS