### PR TITLE
chore: add clean-publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "check-types": "tsc --noEmit true",
     "test": "jest tests --coverage",
     "build": "del-cli 'dist/*' && microbundle build --entry src/index.ts --jsx React.createElement --name react-colorful --css-modules true --tsconfig tsconfig.build.json",
-    "prepublishOnly": "npm run build",
-    "publish": "clean-publish",
+    "publish": "npm run build && clean-publish",
     "start-demo": "parcel demo/src/index.html --out-dir demo/dist --open",
     "build-demo": "del-cli 'demo/dist/*' && parcel build demo/src/index.html --out-dir demo/dist --public-url /react-colorful/",
     "deploy-demo": "npm run build-demo && gh-pages -d demo/dist"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "jest tests --coverage",
     "build": "del-cli 'dist/*' && microbundle build --entry src/index.ts --jsx React.createElement --name react-colorful --css-modules true --tsconfig tsconfig.build.json",
     "prepublishOnly": "npm run build",
+    "publish": "clean-publish",
     "start-demo": "parcel demo/src/index.html --out-dir demo/dist --open",
     "build-demo": "del-cli 'demo/dist/*' && parcel build demo/src/index.html --out-dir demo/dist --public-url /react-colorful/",
     "deploy-demo": "npm run build-demo && gh-pages -d demo/dist"
@@ -140,6 +141,7 @@
     "@types/react-dom": "^16.9.8",
     "@typescript-eslint/eslint-plugin": "^3.9.1",
     "@typescript-eslint/parser": "^3.9.1",
+    "clean-publish": "^1.1.8",
     "del-cli": "^3.0.1",
     "eslint": "^7.5.0",
     "eslint-config-prettier": "^6.11.0",


### PR DESCRIPTION
add `clean-publish` for clean all config fields in `package.json`

@omgovich please run in next release `npm run publish`

you can use `npm run publish -- --without-publish` for testing.
this command build library and create "сlean" package json in tmp folder without publishing to npm, so you can see that everything is okey 🌚