### PR TITLE
Fix pointer displaying in Safari 14

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     {
       "path": "dist/index.module.js",
       "import": "{ RgbaStringColorPicker }",
-      "limit": "2 KB"
+      "limit": "2.1 KB"
     },
     {
       "path": "dist/index.module.js",

--- a/src/components/common/Alpha.tsx
+++ b/src/components/common/Alpha.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { Interactive, Interaction } from "./Interactive";
+import { Pointer } from "./Pointer";
 
 import { hsvaToHslaString } from "../../utils/convert";
 import { formatClassName } from "../../utils/format";
@@ -34,12 +35,6 @@ export const Alpha = ({ className, hsva, onChange }: Props): JSX.Element => {
     backgroundImage: `linear-gradient(90deg, ${colorFrom}, ${colorTo})`,
   };
 
-  const pointerStyle = {
-    top: "50%",
-    left: `${hsva.a * 100}%`,
-    color: hsvaToHslaString(hsva),
-  };
-
   const nodeClassName = formatClassName([
     "react-colorful__alpha",
     styles.alpha,
@@ -47,11 +42,7 @@ export const Alpha = ({ className, hsva, onChange }: Props): JSX.Element => {
     className,
   ]);
 
-  const pointerClassName = formatClassName([
-    "react-colorful__alpha-pointer",
-    styles.pointer,
-    styles.alphaPattern,
-  ]);
+  const pointerClassName = formatClassName(["react-colorful__alpha-pointer", styles.alphaPattern]);
 
   return (
     <div className={nodeClassName}>
@@ -62,7 +53,7 @@ export const Alpha = ({ className, hsva, onChange }: Props): JSX.Element => {
         aria-label="Alpha"
         aria-valuetext={`${Math.round(hsva.a * 100)}%`}
       >
-        <div className={pointerClassName} style={pointerStyle} />
+        <Pointer className={pointerClassName} left={hsva.a} color={hsvaToHslaString(hsva)} />
       </Interactive>
     </div>
   );

--- a/src/components/common/Hue.tsx
+++ b/src/components/common/Hue.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { Interactive, Interaction } from "./Interactive";
+import { Pointer } from "./Pointer";
 
 import { hsvaToHslString } from "../../utils/convert";
 import { formatClassName } from "../../utils/format";
@@ -26,14 +27,7 @@ const HueBase = ({ className, hue, onChange }: Props) => {
     });
   };
 
-  const pointerStyle = {
-    top: "50%",
-    left: `${(hue / 360) * 100}%`,
-    color: hsvaToHslString({ h: hue, s: 100, v: 100, a: 1 }),
-  };
-
   const nodeClassName = formatClassName(["react-colorful__hue", styles.hue, className]);
-  const pointerClassName = formatClassName(["react-colorful__hue-pointer", styles.pointer]);
 
   return (
     <div className={nodeClassName}>
@@ -43,7 +37,11 @@ const HueBase = ({ className, hue, onChange }: Props) => {
         aria-label="Hue"
         aria-valuetext={Math.round(hue)}
       >
-        <div className={pointerClassName} style={pointerStyle} />
+        <Pointer
+          className="react-colorful__hue-pointer"
+          left={hue / 360}
+          color={hsvaToHslString({ h: hue, s: 100, v: 100, a: 1 })}
+        />
       </Interactive>
     </div>
   );

--- a/src/components/common/Pointer.tsx
+++ b/src/components/common/Pointer.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { formatClassName } from "../../utils/format";
+
+import styles from "../../css/styles.css";
+
+interface Props {
+  className?: string;
+  top?: number;
+  left: number;
+  color: string;
+}
+
+export const Pointer = ({ className, color, left, top = 0.5 }: Props): JSX.Element => {
+  const nodeClassName = formatClassName([className, styles.pointer]);
+
+  const style = {
+    top: `${top * 100}%`,
+    left: `${left * 100}%`,
+  };
+
+  return (
+    <div className={nodeClassName} style={style}>
+      <div className={styles.pointerFill} style={{ backgroundColor: color }} />
+    </div>
+  );
+};

--- a/src/components/common/Saturation.tsx
+++ b/src/components/common/Saturation.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Interactive, Interaction } from "./Interactive";
+import { Pointer } from "./Pointer";
 import { HsvaColor } from "../../types";
 import { hsvaToHslString } from "../../utils/convert";
 import { clamp } from "../../utils/clamp";
@@ -31,14 +32,7 @@ const SaturationBase = ({ hsva, onChange }: Props) => {
     backgroundColor: hsvaToHslString({ h: hsva.h, s: 100, v: 100, a: 1 }),
   };
 
-  const pointerStyle = {
-    top: `${100 - hsva.v}%`,
-    left: `${hsva.s}%`,
-    color: hsvaToHslString(hsva),
-  };
-
   const nodeClassName = formatClassName(["react-colorful__saturation", styles.saturation]);
-  const pointerClassName = formatClassName(["react-colorful__saturation-pointer", styles.pointer]);
 
   return (
     <div className={nodeClassName} style={containerStyle}>
@@ -48,7 +42,12 @@ const SaturationBase = ({ hsva, onChange }: Props) => {
         aria-label="Color"
         aria-valuetext={`Saturation ${Math.round(hsva.s)}%, Brightness ${Math.round(hsva.v)}%`}
       >
-        <div className={pointerClassName} style={pointerStyle} />
+        <Pointer
+          className="react-colorful__saturation-pointer"
+          top={1 - hsva.v / 100}
+          left={hsva.s / 100}
+          color={hsvaToHslString(hsva)}
+        />
       </Interactive>
     </div>
   );

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -18,7 +18,7 @@
 }
 
 .alpha:after,
-.pointer:after,
+.pointerFill,
 .alphaGradient {
   content: "";
   position: absolute;
@@ -86,10 +86,6 @@
   border: 2px solid #fff;
   border-radius: 50%;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-}
-
-.pointer:after {
-  background-color: currentColor;
 }
 
 /* Chessboard-like pattern for alpha related elements */

--- a/src/css/styles.css.d.ts
+++ b/src/css/styles.css.d.ts
@@ -7,3 +7,4 @@ export const alphaPattern: string;
 export const lastControl: string;
 export const interactive: string;
 export const pointer: string;
+export const pointerFill: string;

--- a/tests/__snapshots__/components.test.js.snap
+++ b/tests/__snapshots__/components.test.js.snap
@@ -26,8 +26,13 @@ exports[`Renders proper alpha color picker markup 1`] = `
     >
       <div
         class="react-colorful__saturation-pointer pointer"
-        style="top: 0%; left: 100%; color: rgb(255, 0, 0);"
-      />
+        style="top: 0%; left: 100%;"
+      >
+        <div
+          class="pointerFill"
+          style="background-color: rgb(255, 0, 0);"
+        />
+      </div>
     </div>
   </div>
   <div
@@ -42,8 +47,13 @@ exports[`Renders proper alpha color picker markup 1`] = `
     >
       <div
         class="react-colorful__hue-pointer pointer"
-        style="top: 50%; left: 0%; color: rgb(255, 0, 0);"
-      />
+        style="top: 50%; left: 0%;"
+      >
+        <div
+          class="pointerFill"
+          style="background-color: rgb(255, 0, 0);"
+        />
+      </div>
     </div>
   </div>
   <div
@@ -60,9 +70,14 @@ exports[`Renders proper alpha color picker markup 1`] = `
       tabindex="0"
     >
       <div
-        class="react-colorful__alpha-pointer pointer alphaPattern"
-        style="top: 50%; left: 50%; color: rgba(255, 0, 0, 0.5);"
-      />
+        class="react-colorful__alpha-pointer alphaPattern pointer"
+        style="top: 50%; left: 50%;"
+      >
+        <div
+          class="pointerFill"
+          style="background-color: rgba(255, 0, 0, 0.5);"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -85,8 +100,13 @@ exports[`Renders proper color picker markup 1`] = `
     >
       <div
         class="react-colorful__saturation-pointer pointer"
-        style="top: 0%; left: 100%; color: rgb(255, 0, 0);"
-      />
+        style="top: 0%; left: 100%;"
+      >
+        <div
+          class="pointerFill"
+          style="background-color: rgb(255, 0, 0);"
+        />
+      </div>
     </div>
   </div>
   <div
@@ -101,8 +121,13 @@ exports[`Renders proper color picker markup 1`] = `
     >
       <div
         class="react-colorful__hue-pointer pointer"
-        style="top: 50%; left: 0%; color: rgb(255, 0, 0);"
-      />
+        style="top: 50%; left: 0%;"
+      >
+        <div
+          class="pointerFill"
+          style="background-color: rgb(255, 0, 0);"
+        />
+      </div>
     </div>
   </div>
 </div>
@@ -125,8 +150,13 @@ exports[`Works with no props 1`] = `
     >
       <div
         class="react-colorful__saturation-pointer pointer"
-        style="top: 100%; left: 0%; color: rgb(0, 0, 0);"
-      />
+        style="top: 100%; left: 0%;"
+      >
+        <div
+          class="pointerFill"
+          style="background-color: rgb(0, 0, 0);"
+        />
+      </div>
     </div>
   </div>
   <div
@@ -141,8 +171,13 @@ exports[`Works with no props 1`] = `
     >
       <div
         class="react-colorful__hue-pointer pointer"
-        style="top: 50%; left: 0%; color: rgb(255, 0, 0);"
-      />
+        style="top: 50%; left: 0%;"
+      >
+        <div
+          class="pointerFill"
+          style="background-color: rgb(255, 0, 0);"
+        />
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #73 

Safari is a new IE...

Safari 14 doesn't work properly with `currentColor`, so I had to replace a pseudo-element that has `background-color: currentColor` with a regular `div` having `background-color`.

@rschristian Could you take a look? 