### PR TITLE
Round output values

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 ## Features
 
-- **Small**: Just 1,8 KB gzipped (18 times lighter than **react-color**).
+- **Small**: Just 1,9 KB gzipped (17 times lighter than **react-color**).
 - **Tree-shakeable**: Only the parts you use will be imported into your app's bundle.
 - **Fast**: Built with hooks and functional components only.
 - **Bulletproof**: Written in strict TypeScript and covered by 40+ tests.

--- a/src/components/HsvaColorPicker.tsx
+++ b/src/components/HsvaColorPicker.tsx
@@ -3,11 +3,12 @@ import React from "react";
 import { AlphaColorPicker } from "./common/AlphaColorPicker";
 import { ColorModel, ColorPickerBaseProps, HsvaColor } from "../types";
 import { equalColorObjects } from "../utils/compare";
+import { roundHsva } from "../utils/convert";
 
 const colorModel: ColorModel<HsvaColor> = {
   defaultColor: { h: 0, s: 0, v: 0, a: 1 },
   toHsva: (hsva) => hsva,
-  fromHsva: (hsva) => hsva,
+  fromHsva: roundHsva,
   equal: equalColorObjects,
 };
 

--- a/src/components/common/Alpha.tsx
+++ b/src/components/common/Alpha.tsx
@@ -6,6 +6,7 @@ import { Pointer } from "./Pointer";
 import { hsvaToHslaString } from "../../utils/convert";
 import { formatClassName } from "../../utils/format";
 import { clamp } from "../../utils/clamp";
+import { round } from "../../utils/round";
 import { HsvaColor } from "../../types";
 
 import styles from "../../css/styles.css";
@@ -51,7 +52,7 @@ export const Alpha = ({ className, hsva, onChange }: Props): JSX.Element => {
         onMove={handleMove}
         onKey={handleKey}
         aria-label="Alpha"
-        aria-valuetext={`${Math.round(hsva.a * 100)}%`}
+        aria-valuetext={`${round(hsva.a * 100)}%`}
       >
         <Pointer className={pointerClassName} left={hsva.a} color={hsvaToHslaString(hsva)} />
       </Interactive>

--- a/src/components/common/Hue.tsx
+++ b/src/components/common/Hue.tsx
@@ -6,6 +6,7 @@ import { Pointer } from "./Pointer";
 import { hsvaToHslString } from "../../utils/convert";
 import { formatClassName } from "../../utils/format";
 import { clamp } from "../../utils/clamp";
+import { round } from "../../utils/round";
 
 import styles from "../../css/styles.css";
 
@@ -35,7 +36,7 @@ const HueBase = ({ className, hue, onChange }: Props) => {
         onMove={handleMove}
         onKey={handleKey}
         aria-label="Hue"
-        aria-valuetext={Math.round(hue)}
+        aria-valuetext={round(hue)}
       >
         <Pointer
           className="react-colorful__hue-pointer"

--- a/src/components/common/Saturation.tsx
+++ b/src/components/common/Saturation.tsx
@@ -4,6 +4,7 @@ import { Pointer } from "./Pointer";
 import { HsvaColor } from "../../types";
 import { hsvaToHslString } from "../../utils/convert";
 import { clamp } from "../../utils/clamp";
+import { round } from "../../utils/round";
 import { formatClassName } from "../../utils/format";
 import styles from "../../css/styles.css";
 
@@ -40,7 +41,7 @@ const SaturationBase = ({ hsva, onChange }: Props) => {
         onMove={handleMove}
         onKey={handleKey}
         aria-label="Color"
-        aria-valuetext={`Saturation ${Math.round(hsva.s)}%, Brightness ${Math.round(hsva.v)}%`}
+        aria-valuetext={`Saturation ${round(hsva.s)}%, Brightness ${round(hsva.v)}%`}
       >
         <Pointer
           className="react-colorful__saturation-pointer"

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -56,10 +56,10 @@ export const hsvaToHsla = ({ h, s, v, a }: HsvaColor): HslaColor => {
   const hh = ((200 - s) * v) / 100;
 
   return {
-    h: h,
-    s: hh > 0 && hh < 200 ? ((s * v) / 100 / (hh <= 100 ? hh : 200 - hh)) * 100 : 0,
-    l: hh / 2,
-    a,
+    h: round(h),
+    s: round(hh > 0 && hh < 200 ? ((s * v) / 100 / (hh <= 100 ? hh : 200 - hh)) * 100 : 0),
+    l: round(hh / 2),
+    a: round(a, 2),
   };
 };
 
@@ -68,13 +68,13 @@ export const hsvaToHslString = (hsva: HsvaColor): string => {
   return `hsl(${h}, ${s}%, ${l}%)`;
 };
 
-export const hsvaToHsvString = (hsv: HsvaColor): string => {
-  const { h, s, v } = hsv;
+export const hsvaToHsvString = (hsva: HsvaColor): string => {
+  const { h, s, v } = roundHsva(hsva);
   return `hsv(${h}, ${s}%, ${v}%)`;
 };
 
 export const hsvaToHsvaString = (hsva: HsvaColor): string => {
-  const { h, s, v, a } = hsva;
+  const { h, s, v, a } = roundHsva(hsva);
   return `hsva(${h}, ${s}%, ${v}%, ${a})`;
 };
 
@@ -174,8 +174,18 @@ export const rgbaToHsva = ({ r, g, b, a }: RgbaColor): HsvaColor => {
   };
 };
 
+export const roundHsva = (hsva: HsvaColor): HsvaColor => ({
+  h: round(hsva.h),
+  s: round(hsva.s),
+  v: round(hsva.v),
+  a: round(hsva.a, 2),
+});
+
 export const rgbaToRgb = ({ r, g, b }: RgbaColor): RgbColor => ({ r, g, b });
 
 export const hslaToHsl = ({ h, s, l }: HslaColor): HslColor => ({ h, s, l });
 
-export const hsvaToHsv = ({ h, s, v }: HsvaColor): HsvColor => ({ h, s, v });
+export const hsvaToHsv = (hsva: HsvaColor): HsvColor => {
+  const { h, s, v } = roundHsva(hsva);
+  return { h, s, v };
+};

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -1,3 +1,4 @@
+import { round } from "./round";
 import { RgbaColor, RgbColor, HslaColor, HslColor, HsvaColor, HsvColor } from "../types";
 
 export const hexToHsva = (hex: string): HsvaColor => rgbaToHsva(hexToRgba(hex));
@@ -94,9 +95,9 @@ export const hsvaToRgba = ({ h, s, v, a }: HsvaColor): RgbaColor => {
     module = hh % 6;
 
   return {
-    r: Math.round([v, c, b, b, d, v][module] * 255),
-    g: Math.round([d, v, v, c, b, b][module] * 255),
-    b: Math.round([b, b, d, v, v, c][module] * 255),
+    r: round([v, c, b, b, d, v][module] * 255),
+    g: round([d, v, v, c, b, b][module] * 255),
+    b: round([b, b, d, v, v, c][module] * 255),
     a,
   };
 };
@@ -166,9 +167,9 @@ export const rgbaToHsva = ({ r, g, b, a }: RgbaColor): HsvaColor => {
     : 0;
 
   return {
-    h: Math.round(60 * (hh < 0 ? hh + 6 : hh)),
-    s: Math.round(max ? (delta / max) * 100 : 0),
-    v: Math.round((max / 255) * 100),
+    h: round(60 * (hh < 0 ? hh + 6 : hh)),
+    s: round(max ? (delta / max) * 100 : 0),
+    v: round((max / 255) * 100),
     a,
   };
 };

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -98,7 +98,7 @@ export const hsvaToRgba = ({ h, s, v, a }: HsvaColor): RgbaColor => {
     r: round([v, c, b, b, d, v][module] * 255),
     g: round([d, v, v, c, b, b][module] * 255),
     b: round([b, b, d, v, v, c][module] * 255),
-    a,
+    a: round(a, 2),
   };
 };
 

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -118,12 +118,12 @@ export const hsvaStringToHsva = (hsvString: string): HsvaColor => {
 
   if (!match) return { h: 0, s: 0, v: 0, a: 1 };
 
-  return {
+  return roundHsva({
     h: Number(match[1]),
     s: Number(match[2]),
     v: Number(match[3]),
     a: match[4] === undefined ? 1 : Number(match[4]),
-  };
+  });
 };
 
 export const hsvStringToHsva = hsvaStringToHsva;

--- a/src/utils/round.ts
+++ b/src/utils/round.ts
@@ -1,0 +1,5 @@
+export const round = (number: number, digits = 0): number => {
+  // We wrap `toFixed` call with `Number()` to remove insignificant trailing zeros
+  // because `(1).toFixed(2) // 1.00`
+  return Number(number.toFixed(digits));
+};

--- a/src/utils/round.ts
+++ b/src/utils/round.ts
@@ -1,5 +1,3 @@
-export const round = (number: number, digits = 0): number => {
-  // We wrap `toFixed` call with `Number()` to remove insignificant trailing zeros
-  // because `(1).toFixed(2) // 1.00`
-  return Number(number.toFixed(digits));
+export const round = (number: number, digits = 0, base = Math.pow(10, digits)): number => {
+  return Math.round(base * number) / base;
 };

--- a/tests/components.test.js
+++ b/tests/components.test.js
@@ -208,7 +208,7 @@ it("Changes hue with arrow keys", async () => {
 
 it("Changes alpha with arrow keys", async () => {
   const handleChange = jest.fn();
-  const initialValue = { h: 180, s: 0, l: 50, a: 0.5 };
+  const initialValue = { h: 180, s: 0, v: 50, a: 0.5 };
 
   const result = render(<HsvaColorPicker color={initialValue} onChange={handleChange} />);
   const alpha = result.container.querySelector(".react-colorful__alpha .interactive");

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,5 +1,5 @@
 // HEX
-import { hexToHsva, hsvaToHex } from "../src/utils/convert";
+import { hexToHsva, hsvaToHex, roundHsva } from "../src/utils/convert";
 import { equalHex } from "../src/utils/compare";
 import { validHex } from "../src/utils/validate";
 // HSLA
@@ -28,6 +28,7 @@ import { hsvaToHsvString, hsvStringToHsva } from "../src/utils/convert";
 import { equalColorObjects, equalColorString } from "../src/utils/compare";
 import { formatClassName } from "../src/utils/format";
 import { clamp } from "../src/utils/clamp";
+import { round } from "../src/utils/round";
 
 it("Converts HEX to HSVA", () => {
   expect(hexToHsva("#ffffff")).toMatchObject({ h: 0, s: 0, v: 100, a: 1 });
@@ -55,11 +56,11 @@ it("Converts HSVA to HEX", () => {
 it("Converts HSVA to HSLA", () => {
   let test = (input, output) => expect(hsvaToHsla(input)).toMatchObject(output);
 
-  test({ h: 0, s: 0, v: 100 }, { h: 0, s: 0, l: 100 });
-  test({ h: 60, s: 100, v: 100 }, { h: 60, s: 100, l: 50 });
-  test({ h: 0, s: 100, v: 100 }, { h: 0, s: 100, l: 50 });
-  test({ h: 0, s: 0, v: 0 }, { h: 0, s: 0, l: 0 });
-  test({ h: 200, s: 40, v: 40 }, { h: 200, s: 25, l: 32 });
+  test({ h: 0, s: 0, v: 100, a: 1 }, { h: 0, s: 0, l: 100, a: 1 });
+  test({ h: 60, s: 100, v: 100, a: 1 }, { h: 60, s: 100, l: 50, a: 1 });
+  test({ h: 0, s: 100, v: 100, a: 1 }, { h: 0, s: 100, l: 50, a: 1 });
+  test({ h: 0, s: 0, v: 0, a: 1 }, { h: 0, s: 0, l: 0, a: 1 });
+  test({ h: 200, s: 40, v: 40, a: 0.499 }, { h: 200, s: 25, l: 32, a: 0.5 });
 });
 
 it("Converts HSLA to HSVA", () => {
@@ -125,6 +126,7 @@ it("Converts RGBA string to HSVA", () => {
 it("Converts HSVA to HSVA string", () => {
   expect(hsvaToHsvaString({ h: 0, s: 0, v: 100, a: 1 })).toBe("hsva(0, 0%, 100%, 1)");
   expect(hsvaToHsvaString({ h: 200, s: 40, v: 40, a: 0 })).toBe("hsva(200, 40%, 40%, 0)");
+  expect(hsvaToHsvaString({ h: 3.33, s: 5.55, v: 6.66, a: 0.567 })).toBe("hsva(3, 6%, 7%, 0.57)");
 });
 
 it("Converts HSVA to HSV string", () => {
@@ -133,11 +135,18 @@ it("Converts HSVA to HSV string", () => {
 });
 
 it("Converts HSV string to HSVA", () => {
-  expect(hsvStringToHsva("hsv(0, 10.5%, 0%)")).toMatchObject({ h: 0, s: 10.5, v: 0, a: 1 });
+  expect(hsvStringToHsva("hsv(0, 10.5%, 0%)")).toMatchObject({ h: 0, s: 11, v: 0, a: 1 });
 });
 
 it("Converts HSVA string to HSVA", () => {
-  expect(hsvaStringToHsva("hsva(0, 10.5%, 0, 0.5)")).toMatchObject({ h: 0, s: 10.5, v: 0, a: 0.5 });
+  expect(hsvaStringToHsva("hsva(0, 10.5%, 0, 0.5)")).toMatchObject({ h: 0, s: 11, v: 0, a: 0.5 });
+});
+
+it("Rounds HSVA", () => {
+  let test = (input, output) => expect(roundHsva(input)).toMatchObject(output);
+
+  test({ h: 1, s: 1, v: 1, a: 1 }, { h: 1, s: 1, v: 1, a: 1 });
+  test({ h: 3.3333, s: 4.4444, v: 5.5555, a: 0.6789 }, { h: 3, s: 4, v: 6, a: 0.68 });
 });
 
 it("Trims alpha-channel", () => {
@@ -187,6 +196,17 @@ it("Formats a class name", () => {
   expect(formatClassName(["one"])).toBe("one");
   expect(formatClassName(["one", "two", "three"])).toBe("one two three");
   expect(formatClassName([false, "two", null])).toBe("two");
+});
+
+it("Rounds a number", () => {
+  expect(round(0)).toBe(0);
+  expect(round(1)).toBe(1);
+  expect(round(0.1)).toBe(0);
+  expect(round(0.9)).toBe(1);
+  expect(round(0.123, 2)).toBe(0.12);
+  expect(round(0.789, 2)).toBe(0.79);
+  expect(round(1, 10)).toBe(1);
+  expect(round(0.123, 10)).toBe(0.123);
 });
 
 it("Clamps a number between bounds", () => {

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -94,7 +94,7 @@ it("Converts HSVA to RGBA", () => {
   let test = (input, output) => expect(hsvaToRgba(input)).toMatchObject(output);
 
   test({ h: 0, s: 0, v: 100, a: 1 }, { r: 255, g: 255, b: 255, a: 1 });
-  test({ h: 0, s: 100, v: 100, a: 0.5 }, { r: 255, g: 0, b: 0, a: 0.5 });
+  test({ h: 0, s: 100, v: 100, a: 0.567 }, { r: 255, g: 0, b: 0, a: 0.57 });
 });
 
 it("Converts RGBA to HSVA", () => {


### PR DESCRIPTION
Closes #76

## Problem

![image](https://user-images.githubusercontent.com/206567/96647021-b1ac8500-1335-11eb-8b23-39f4a5aafbd7.png)

All color models except HEX and RGB are awkward to use because output values have too many digits after the decimal point.

## What I did

The internal value is still super accurate (like `{ h: 1.23456789, s: 2.3456789, v: 3.4567, a: 0.9999999 }`).
Why? To keep the movement of pointers super smooth even when the picker size is 1000x1000.

This PR makes all output values rounded to the nearest integer.
Only alpha value has 2 digits to appear after the decimal point.

```js
hsl(200.4326236, 25.124125%, 32.121212%, 0.6666666) // will be impossible to get after merging this PR
hsl(200, 25%, 32%, 0.67) // that's what we going to return
```

@rschristian @molefrog Could I ask you to review the PR?



