### PR TITLE
CSS-in-JS experiments

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,17 @@
     "size": "npm run build && size-limit",
     "check-types": "tsc --noEmit true",
     "test": "jest tests --coverage",
-    "build": "del-cli 'dist/*' && microbundle build --entry src/index.ts --jsx React.createElement --name react-colorful --css-modules false --tsconfig tsconfig.build.json",
+    "build": "del-cli 'dist/*' && microbundle build --entry src/index.ts --jsx React.createElement --name react-colorful --css-modules false --tsconfig tsconfig.build.json && node scripts/inject-css-to-js-dist.js",
     "prepublishOnly": "npm run build",
     "start-demo": "parcel demo/src/index.html --out-dir demo/dist --open",
     "build-demo": "del-cli 'demo/dist/*' && parcel build demo/src/index.html --out-dir demo/dist --public-url /react-colorful/",
     "deploy-demo": "npm run build-demo && gh-pages -d demo/dist"
   },
   "size-limit": [
+    {
+      "path": "dist/index.module.js",
+      "limit": "4 KB"
+    },
     {
       "path": "dist/index.module.js",
       "import": "{ HexColorPicker }",
@@ -172,6 +176,7 @@
     "prettier": "2.0.5",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
+    "replace-in-file": "^6.1.0",
     "size-limit": "^4.6.2",
     "ts-jest": "^26.2.0",
     "typescript": "^3.9.7",

--- a/scripts/inject-css-to-js-dist.js
+++ b/scripts/inject-css-to-js-dist.js
@@ -1,0 +1,18 @@
+const fs = require("fs");
+const path = require("path");
+const replace = require("replace-in-file");
+
+const stylesPath = path.join(__dirname, "../dist/index.css");
+const filesPath = path.join(__dirname, "../dist/*.js");
+
+// Read minified CSS from the dist folder
+const styles = fs.readFileSync(stylesPath, "utf8").replace(/"/g, '\\"');
+
+// Inject CSS-code to the builded JS-files
+const results = replace.sync({
+  files: filesPath,
+  from: ".react-colorful{}",
+  to: styles,
+});
+
+console.log(`🔨 CSS code was successfully added to ${results.length} JS-files`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,5 +16,9 @@ export { RgbStringColorPicker } from "./components/RgbStringColorPicker";
 // Additional components
 export { HexColorInput } from "./components/HexColorInput";
 
+// Export styles as string for those who uses a CSS-in-JS library and doesn't have a CSS-loader.
+// The marker below (DO NOT TOUCH) will be replaced with the real styles during the package building
+export const styles = ".react-colorful{}";
+
 // Color model types
 export { RgbColor, RgbaColor, HslColor, HslaColor, HsvColor, HsvaColor } from "./types";


### PR DESCRIPTION
The first (possible) step of our "CSS-in-JS" project.

Example 1:
```jsx
import { HexColorPicker, styles } from 'react-colorful'
import styled from '@emotion/styled'

const Container = styled('div')`
  ${styles};
`

const YourComponent = () => {
  const [color, setColor] = useState("#aabbcc");
  return (
    <Container>
      <HexColorPicker color={color} onChange={setColor} />
    </Container>
  )
};
```

Example 2:
```jsx
import { HexColorPicker, styles } from 'react-colorful'
import { Global } from '@emotion/core'

const YourComponent = () => {
  const [color, setColor] = useState("#aabbcc");
  return (
    <>
      <Global styles={styles} />
      <HexColorPicker color={color} onChange={setColor} />
    </>
  )
};
```

By exporting CSS as a string we could open an opportunity to create a recipes for most of CSS-in-JS libraries or even create our own wrappers around react-colorful for each CSS-in-JS solution.

@rschristian @molefrog Thought?