### PR TITLE
Get rid of `useLayoutEffect` warning when using on the server

### DIFF
--- a/src/components/common/Interactive.tsx
+++ b/src/components/common/Interactive.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useLayoutEffect, useRef, useCallback } from "react";
+import React, { useState, useRef, useCallback } from "react";
 
+import { useIsomorphicLayoutEffect } from "../../hooks/useIsomorphicLayoutEffect";
 import { useEventCallback } from "../../hooks/useEventCallback";
 import { clamp } from "../../utils/clamp";
 
@@ -98,7 +99,7 @@ const InteractiveBase = ({ onMove, onKey, ...rest }: Props) => {
     [handleMove, handleMoveEnd]
   );
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     toggleDocumentEvents(isDragging);
     return () => {
       isDragging && toggleDocumentEvents(false);

--- a/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,0 +1,7 @@
+import { useLayoutEffect, useEffect } from "react";
+
+// React currently throws a warning when using useLayoutEffect on the server.
+// To get around it, we can conditionally useEffect on the server (no-op) and
+// useLayoutEffect in the browser.
+export const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect;


### PR DESCRIPTION
Closes #94

> Warning: useLayoutEffect does nothing on the server, because its effect cannot be encoded into the server renderer's output format. This will lead to a mismatch between the initial, non-hydrated UI and the intended UI. To avoid this, useLayoutEffect should only be used in components that render exclusively on the client. See https://reactjs.org/link/uselayouteffect-ssr for common fixes.

The hack is copied from `react-redux` repo.