### PR TITLE
CSS-in-JS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 ## Features
 
-- **Small**: Just 1,9 KB gzipped (17 times lighter than **react-color**).
+- **Small**: Just 2,5 KB gzipped (14 times lighter than **react-color**).
 - **Tree-shakeable**: Only the parts you use will be imported into your app's bundle.
 - **Fast**: Built with hooks and functional components only.
 - **Bulletproof**: Written in strict TypeScript and covered by 40+ tests.
@@ -56,7 +56,6 @@ npm install react-colorful --save
 
 ```js
 import { HexColorPicker } from "react-colorful";
-import "react-colorful/dist/index.css";
 
 const YourComponent = () => {
   const [color, setColor] = useState("#aabbcc");
@@ -93,7 +92,6 @@ We provide 12 additional color picker components for different color models, unl
 
 ```js
 import { RgbColorPicker } from "react-colorful";
-import "react-colorful/dist/index.css";
 
 const YourComponent = () => {
   const [color, setColor] = useState({ r: 50, g: 100, b: 150 });
@@ -141,7 +139,6 @@ As you probably noticed the color picker itself does not include an input field,
 
 ```js
 import { HexColorPicker, HexColorInput } from "react-colorful";
-import "react-colorful/dist/index.css";
 
 const YourComponent = () => {
   const [color, setColor] = useState("#aabbcc");

--- a/package.json
+++ b/package.json
@@ -105,6 +105,9 @@
     "transform": {
       "\\.js$": "jest-esm-jsx-transform",
       "^.+\\.tsx?$": "ts-jest"
+    },
+    "moduleNameMapper": {
+      "\\.css$": "identity-obj-proxy"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -168,7 +168,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^26.3.0",
     "jest-esm-jsx-transform": "^1.0.0",
-    "microbundle": "^0.12.3",
+    "microbundle": "^0.13.0",
     "parcel-bundler": "^1.12.4",
     "postcss-modules": "^3.2.0",
     "prettier": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-colorful",
   "version": "4.4.4",
-  "description": "🎨 A tiny (1,9 KB) color picker component for React and Preact apps. Fast, well-tested, dependency-free, mobile-friendly and accessible",
+  "description": "🎨 A tiny (2,5 KB) color picker component for React and Preact apps. Fast, well-tested, dependency-free, mobile-friendly and accessible",
   "source": "src/index.ts",
   "main": "dist/index.js",
   "module": "dist/index.module.js",
@@ -32,77 +32,75 @@
     {
       "path": "dist/index.module.js",
       "import": "{ HexColorPicker }",
-      "limit": "2 KB"
+      "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
       "import": "{ HslColorPicker }",
-      "limit": "2 KB"
+      "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
       "import": "{ HslaColorPicker }",
-      "limit": "2 KB"
+      "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
       "import": "{ HslStringColorPicker }",
-      "limit": "2 KB"
+      "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
       "import": "{ HslaStringColorPicker }",
-      "limit": "2 KB"
+      "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
       "import": "{ HsvColorPicker }",
-      "limit": "2 KB"
+      "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
       "import": "{ HsvaColorPicker }",
-      "limit": "2 KB"
+      "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
       "import": "{ HsvStringColorPicker }",
-      "limit": "2 KB"
+      "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
       "import": "{ HsvaStringColorPicker }",
-      "limit": "2 KB"
+      "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
       "import": "{ RgbColorPicker }",
-      "limit": "2 KB"
+      "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
       "import": "{ RgbaColorPicker }",
-      "limit": "2 KB"
+      "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
       "import": "{ RgbStringColorPicker }",
-      "limit": "2 KB"
+      "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
       "import": "{ RgbaStringColorPicker }",
-      "limit": "2.1 KB"
+      "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
       "import": "{ HexColorInput }",
-      "limit": "2 KB"
+      "limit": "3 KB"
     }
   ],
-  "sideEffects": [
-    "*.css"
-  ],
+  "sideEffects": false,
   "jest": {
     "verbose": true,
     "transform": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
       "^.+\\.tsx?$": "ts-jest"
     },
     "moduleNameMapper": {
-      "\\.css$": "identity-obj-proxy"
+      "\\.css$": "<rootDir>/tests/__mocks__/styles.css.mock.ts"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
       "umd": "./dist/index.umd.js",
       "import": "./dist/index.module.js",
       "require": "./dist/index.js"
-    },
-    "./dist/index.css": "./dist/index.css"
+    }
   },
   "scripts": {
     "lint": "eslint src/**/*.{ts,tsx} demo/src/**/*.{ts,tsx}",
@@ -106,13 +105,10 @@
     "transform": {
       "\\.js$": "jest-esm-jsx-transform",
       "^.+\\.tsx?$": "ts-jest"
-    },
-    "moduleNameMapper": {
-      "\\.css$": "identity-obj-proxy"
     }
   },
   "files": [
-    "dist/*.{js,ts,map,css}",
+    "dist/*.{js,ts,map}",
     "dist/components/*.ts",
     "LICENSE",
     "ACKNOWLEDGMENTS",
@@ -169,7 +165,6 @@
     "microbundle": "^0.13.0",
     "parcel-bundler": "^1.12.4",
     "parcel-plugin-css-to-string": "^2.5.1",
-    "postcss-modules": "^3.2.0",
     "prettier": "2.0.5",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "size": "npm run build && size-limit",
     "check-types": "tsc --noEmit true",
     "test": "jest tests --coverage",
-    "build": "del-cli 'dist/*' && microbundle build --entry src/index.ts --jsx React.createElement --name react-colorful --css-modules false --tsconfig tsconfig.build.json",
+    "build": "del-cli 'dist/*' && microbundle build --entry src/index.ts --jsx React.createElement --name react-colorful --css inline --tsconfig tsconfig.build.json",
     "prepublishOnly": "npm run build",
     "start-demo": "parcel demo/src/index.html --out-dir demo/dist --open",
     "build-demo": "del-cli 'demo/dist/*' && parcel build demo/src/index.html --out-dir demo/dist --public-url https://omgovich.github.io/react-colorful/",
@@ -170,13 +170,14 @@
     "jest-esm-jsx-transform": "^1.0.0",
     "microbundle": "^0.13.0",
     "parcel-bundler": "^1.12.4",
+    "parcel-plugin-css-to-string": "^2.5.1",
     "postcss-modules": "^3.2.0",
     "prettier": "2.0.5",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "size-limit": "^4.6.2",
     "ts-jest": "^26.2.0",
-    "typescript": "^3.9.7",
+    "typescript": "^4.1.3",
     "use-throttled-effect": "0.0.7"
   }
 }

--- a/src/components/common/AlphaColorPicker.tsx
+++ b/src/components/common/AlphaColorPicker.tsx
@@ -6,9 +6,8 @@ import { Alpha } from "./Alpha";
 
 import { ColorModel, ColorPickerBaseProps, AnyColor } from "../../types";
 import { useColorManipulation } from "../../hooks/useColorManipulation";
+import { useStyleSheet } from "../../hooks/useStyleSheet";
 import { formatClassName } from "../../utils/format";
-
-import "../../css/styles.css";
 
 interface Props<T extends AnyColor> extends Partial<ColorPickerBaseProps<T>> {
   colorModel: ColorModel<T>;
@@ -20,6 +19,8 @@ export const AlphaColorPicker = <T extends AnyColor>({
   color = colorModel.defaultColor,
   onChange,
 }: Props<T>): JSX.Element => {
+  useStyleSheet();
+
   const [hsva, updateHsva] = useColorManipulation<T>(colorModel, color, onChange);
 
   const nodeClassName = formatClassName(["react-colorful", className]);

--- a/src/components/common/ColorPicker.tsx
+++ b/src/components/common/ColorPicker.tsx
@@ -5,9 +5,8 @@ import { Saturation } from "./Saturation";
 
 import { ColorModel, ColorPickerBaseProps, AnyColor } from "../../types";
 import { useColorManipulation } from "../../hooks/useColorManipulation";
+import { useStyleSheet } from "../../hooks/useStyleSheet";
 import { formatClassName } from "../../utils/format";
-
-import "../../css/styles.css";
 
 interface Props<T extends AnyColor> extends Partial<ColorPickerBaseProps<T>> {
   colorModel: ColorModel<T>;
@@ -19,6 +18,8 @@ export const ColorPicker = <T extends AnyColor>({
   color = colorModel.defaultColor,
   onChange,
 }: Props<T>): JSX.Element => {
+  useStyleSheet();
+
   const [hsva, updateHsva] = useColorManipulation<T>(colorModel, color, onChange);
 
   const nodeClassName = formatClassName(["react-colorful", className]);

--- a/src/css/styles.css.d.ts
+++ b/src/css/styles.css.d.ts
@@ -1,0 +1,2 @@
+declare const cssString: string;
+export default cssString;

--- a/src/hooks/useStyleSheet.ts
+++ b/src/hooks/useStyleSheet.ts
@@ -1,0 +1,16 @@
+import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect";
+import styles from "../css/styles.css";
+
+let sheet: HTMLStyleElement | null;
+
+/**
+ * Injects CSS code into the document's <head>
+ */
+export const useStyleSheet = (): void => {
+  useIsomorphicLayoutEffect(() => {
+    if (typeof document !== "undefined" && !sheet) {
+      sheet = document.head.appendChild(document.createElement("style"));
+      sheet.innerHTML = styles;
+    }
+  }, []);
+};

--- a/src/hooks/useStyleSheet.ts
+++ b/src/hooks/useStyleSheet.ts
@@ -1,16 +1,18 @@
 import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect";
+
+// Bundler is configured to load this as a processed minified CSS-string
 import styles from "../css/styles.css";
 
-let sheet: HTMLStyleElement | null;
+let styleElement: HTMLStyleElement | undefined;
 
 /**
  * Injects CSS code into the document's <head>
  */
 export const useStyleSheet = (): void => {
   useIsomorphicLayoutEffect(() => {
-    if (typeof document !== "undefined" && !sheet) {
-      sheet = document.head.appendChild(document.createElement("style"));
-      sheet.innerHTML = styles;
+    if (typeof document !== "undefined" && !styleElement) {
+      styleElement = document.head.appendChild(document.createElement("style"));
+      styleElement.innerHTML = styles;
     }
   }, []);
 };

--- a/tests/__mocks__/styles.css.mock.ts
+++ b/tests/__mocks__/styles.css.mock.ts
@@ -1,0 +1,1 @@
+export default ".react-colorful{}";

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src"]
+  "include": ["./src/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "declaration": true,
     "strict": true
   },
-  "include": ["src", "test", "demo/src"]
+  "include": ["./src/**/*", "./test/**/*", "./demo/src/**/*"]
 }


### PR DESCRIPTION
A lot of projects having trouble installing **react-colorful** because they do not have any CSS-loader.
Also, it blocks many developers from including our library as part of their public component libraries since most of them are 100% CSS-in-JS.

For example, I wanted to add **react-colorful** to [react-three-gui](https://github.com/birkir/react-three-gui) but this project bundles via `tsdx` and do not support .css at all. 

Solution: move the styles of our picker to JS.