### PR TITLE
ci: Running lint/build/test on PR too

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -1,6 +1,6 @@
 name: Node.js CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Currently the CI isn't running against PRs, so you can't see if they fail linting/building/testing

I imagine you'd want that enabled, as it'd catch the simple errors (like the multiple linting ones that I just had to fix, whoops)