### PR TITLE
tune size-limit config

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,71 +30,85 @@
   "size-limit": [
     {
       "path": "dist/index.module.js",
+      "name": "HexColorPicker",
       "import": "{ HexColorPicker }",
       "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
+      "name": "HslColorPicker",
       "import": "{ HslColorPicker }",
       "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
+      "name": "HslaColorPicker",
       "import": "{ HslaColorPicker }",
       "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
+      "name": "HslStringColorPicker",
       "import": "{ HslStringColorPicker }",
       "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
+      "name": "HslaStringColorPicker",
       "import": "{ HslaStringColorPicker }",
       "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
+      "name": "HsvColorPicker",
       "import": "{ HsvColorPicker }",
       "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
+      "name": "HsvaColorPicker",
       "import": "{ HsvaColorPicker }",
       "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
+      "name": "HsvStringColorPicker",
       "import": "{ HsvStringColorPicker }",
       "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
+      "name": "HsvaStringColorPicker",
       "import": "{ HsvaStringColorPicker }",
       "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
+      "name": "RgbColorPicker",
       "import": "{ RgbColorPicker }",
       "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
+      "name": "RgbaColorPicker",
       "import": "{ RgbaColorPicker }",
       "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
+      "name": "RgbStringColorPicker",
       "import": "{ RgbStringColorPicker }",
       "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
+      "name": "RgbaStringColorPicker",
       "import": "{ RgbaStringColorPicker }",
       "limit": "3 KB"
     },
     {
       "path": "dist/index.module.js",
+      "name": "HexColorInput",
       "import": "{ HexColorInput }",
       "limit": "3 KB"
     }


### PR DESCRIPTION
add names so size-limit shows component name not `dist/index.module.js` for each check


```

  HexColorPicker
  Size limit: 3 KB
  Size:       2.66 KB with all dependencies, minified and gzipped
  
  HslColorPicker
  Size limit: 3 KB
  Size:       2.38 KB with all dependencies, minified and gzipped
  
  HslaColorPicker
  Size limit: 3 KB
  Size:       2.47 KB with all dependencies, minified and gzipped
  
  HslStringColorPicker
  Size limit: 3 KB
  Size:       2.46 KB with all dependencies, minified and gzipped
  
  HslaStringColorPicker
  Size limit: 3 KB
  Size:       2.58 KB with all dependencies, minified and gzipped

```