### PR TITLE
HTML attributes support

### DIFF
--- a/src/components/common/AlphaColorPicker.tsx
+++ b/src/components/common/AlphaColorPicker.tsx
@@ -18,6 +18,7 @@ export const AlphaColorPicker = <T extends AnyColor>({
   colorModel,
   color = colorModel.defaultColor,
   onChange,
+  ...rest
 }: Props<T>): JSX.Element => {
   useStyleSheet();
 
@@ -26,7 +27,7 @@ export const AlphaColorPicker = <T extends AnyColor>({
   const nodeClassName = formatClassName(["react-colorful", className]);
 
   return (
-    <div className={nodeClassName}>
+    <div {...rest} className={nodeClassName}>
       <Saturation hsva={hsva} onChange={updateHsva} />
       <Hue hue={hsva.h} onChange={updateHsva} />
       <Alpha hsva={hsva} onChange={updateHsva} className="react-colorful__last-control" />

--- a/src/components/common/ColorPicker.tsx
+++ b/src/components/common/ColorPicker.tsx
@@ -17,6 +17,7 @@ export const ColorPicker = <T extends AnyColor>({
   colorModel,
   color = colorModel.defaultColor,
   onChange,
+  ...rest
 }: Props<T>): JSX.Element => {
   useStyleSheet();
 
@@ -25,7 +26,7 @@ export const ColorPicker = <T extends AnyColor>({
   const nodeClassName = formatClassName(["react-colorful", className]);
 
   return (
-    <div className={nodeClassName}>
+    <div {...rest} className={nodeClassName}>
       <Saturation hsva={hsva} onChange={updateHsva} />
       <Hue hue={hsva.h} onChange={updateHsva} className="react-colorful__last-control" />
     </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import React from "react";
+
 export interface RgbColor {
   r: number;
   g: number;
@@ -39,8 +41,12 @@ export interface ColorModel<T extends AnyColor> {
   equal: (first: T, second: T) => boolean;
 }
 
-export interface ColorPickerBaseProps<T extends AnyColor> {
-  className: string;
+type ColorPickerHTMLAttributes = Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  "color" | "onChange" | "onChangeCapture"
+>;
+
+export interface ColorPickerBaseProps<T extends AnyColor> extends ColorPickerHTMLAttributes {
   color: T;
   onChange: (newColor: T) => void;
 }

--- a/tests/__snapshots__/components.test.js.snap
+++ b/tests/__snapshots__/components.test.js.snap
@@ -1,5 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Accepts any valid \`div\` attributes 1`] = `
+<div
+  aria-hidden="false"
+  class="react-colorful"
+  id="my-id"
+>
+  <div
+    class="react-colorful__saturation"
+    style="background-color: rgb(255, 0, 0);"
+  >
+    <div
+      aria-label="Color"
+      aria-valuetext="Saturation 0%, Brightness 0%"
+      class="react-colorful__interactive"
+      role="slider"
+      tabindex="0"
+    >
+      <div
+        class="react-colorful__pointer react-colorful__saturation-pointer"
+        style="top: 100%; left: 0%;"
+      >
+        <div
+          class="react-colorful__pointer-fill"
+          style="background-color: rgb(0, 0, 0);"
+        />
+      </div>
+    </div>
+  </div>
+  <div
+    class="react-colorful__hue react-colorful__last-control"
+  >
+    <div
+      aria-label="Hue"
+      aria-valuetext="0"
+      class="react-colorful__interactive"
+      role="slider"
+      tabindex="0"
+    >
+      <div
+        class="react-colorful__pointer react-colorful__hue-pointer"
+        style="top: 50%; left: 0%;"
+      >
+        <div
+          class="react-colorful__pointer-fill"
+          style="background-color: rgb(255, 0, 0);"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Renders \`HexColorInput\` component properly 1`] = `
 <input
   class="custom-input"

--- a/tests/components.test.js
+++ b/tests/components.test.js
@@ -298,6 +298,20 @@ it("Sets proper `aria-valuetext` attribute value", async () => {
   expect(saturation.getAttribute("aria-valuetext")).toBe("Saturation 100%, Brightness 100%");
 });
 
+it("Accepts any valid `div` attributes", () => {
+  const result = render(<HexColorPicker id="my-id" aria-hidden="false" />);
+
+  expect(result.container.firstChild).toMatchSnapshot();
+});
+
+it("Supports any event that a regular div does", () => {
+  const handleHover = jest.fn();
+  const result = render(<HsvaColorPicker onMouseEnter={handleHover} />);
+  fireEvent.mouseEnter(result.container.firstChild);
+
+  expect(handleHover).toHaveReturnedTimes(1);
+});
+
 it("Renders `HexColorInput` component properly", () => {
   const result = render(
     <HexColorInput className="custom-input" color="#F00" placeholder="AABBCC" />


### PR DESCRIPTION
I was working on some demos recently and noticed that it's not possible to add `id` or another HTML attribute to the root div. Also the picker does not support native DOM events that a regular `div` does (e.g. `onMouseEnter`). 