### PR TITLE
Add fallback to the exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
       "browser": "./dist/index.module.js",
       "umd": "./dist/index.umd.js",
       "import": "./dist/index.module.js",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "default": "./dist/index.module.js"
     }
   },
   "scripts": {
@@ -23,6 +24,8 @@
     "test": "jest tests --coverage",
     "build": "del-cli 'dist/*' && microbundle build --entry src/index.ts --jsx React.createElement --name react-colorful --css inline --tsconfig tsconfig.build.json",
     "prepublishOnly": "npm run build",
+    "check-release": "npm publish --dry-run",
+    "release": "npm publish",
     "start-demo": "parcel demo/src/index.html --out-dir demo/dist --open",
     "build-demo": "del-cli 'demo/dist/*' && parcel build demo/src/index.html --out-dir demo/dist --public-url https://omgovich.github.io/react-colorful/",
     "deploy-demo": "npm run build-demo && gh-pages -d demo/dist"


### PR DESCRIPTION
See [this Twitter discussion](https://twitter.com/Omgovich/status/1379904772170465280).

Added `"default"` key to the export map pointing to the ESM file as described in the [Webpack docs](https://webpack.js.org/guides/package-exports/#conditional-syntax).