### PR TITLE
Support modern CSS color notations

### DIFF
--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -1,6 +1,16 @@
 import { round } from "./round";
 import { RgbaColor, RgbColor, HslaColor, HslColor, HsvaColor, HsvColor } from "../types";
 
+/**
+ * Valid CSS <angle> units.
+ * https://developer.mozilla.org/en-US/docs/Web/CSS/angle
+ */
+const angleUnits: Record<string, number> = {
+  grad: 360 / 400,
+  turn: 360,
+  rad: 360 / (Math.PI * 2),
+};
+
 export const hexToHsva = (hex: string): HsvaColor => rgbaToHsva(hexToRgba(hex));
 
 export const hexToRgba = (hex: string): RgbaColor => {
@@ -23,17 +33,21 @@ export const hexToRgba = (hex: string): RgbaColor => {
   };
 };
 
+export const parseHue = (value: string, unit = "deg"): number => {
+  return Number(value) * (angleUnits[unit] || 1);
+};
+
 export const hslaStringToHsva = (hslString: string): HsvaColor => {
-  const matcher = /hsla?\((\d+\.?\d*),\s*(\d+\.?\d*)%?,\s*(\d+\.?\d*)%?,?\s*(\d+\.?\d*)?\)/;
+  const matcher = /hsla?\(?\s*(-?\d*\.?\d+)(deg|rad|grad|turn)?[,\s]+(-?\d*\.?\d+)%?[,\s]+(-?\d*\.?\d+)%?,?\s*[/\s]*(-?\d*\.?\d+)?(%)?\s*\)?/i;
   const match = matcher.exec(hslString);
 
   if (!match) return { h: 0, s: 0, v: 0, a: 1 };
 
   return hslaToHsva({
-    h: Number(match[1]),
-    s: Number(match[2]),
-    l: Number(match[3]),
-    a: match[4] === undefined ? 1 : Number(match[4]),
+    h: parseHue(match[1], match[2]),
+    s: Number(match[3]),
+    l: Number(match[4]),
+    a: match[5] === undefined ? 1 : Number(match[5]) / (match[6] ? 100 : 1),
   });
 };
 
@@ -113,32 +127,32 @@ export const hsvaToRgbaString = (hsva: HsvaColor): string => {
 };
 
 export const hsvaStringToHsva = (hsvString: string): HsvaColor => {
-  const matcher = /hsva?\((\d+\.?\d*),\s*(\d+\.?\d*)%?,\s*(\d+\.?\d*)%?,?\s*(\d+\.?\d*)?\)/;
+  const matcher = /hsva?\(?\s*(-?\d*\.?\d+)(deg|rad|grad|turn)?[,\s]+(-?\d*\.?\d+)%?[,\s]+(-?\d*\.?\d+)%?,?\s*[/\s]*(-?\d*\.?\d+)?(%)?\s*\)?/i;
   const match = matcher.exec(hsvString);
 
   if (!match) return { h: 0, s: 0, v: 0, a: 1 };
 
   return roundHsva({
-    h: Number(match[1]),
-    s: Number(match[2]),
-    v: Number(match[3]),
-    a: match[4] === undefined ? 1 : Number(match[4]),
+    h: parseHue(match[1], match[2]),
+    s: Number(match[3]),
+    v: Number(match[4]),
+    a: match[5] === undefined ? 1 : Number(match[5]) / (match[6] ? 100 : 1),
   });
 };
 
 export const hsvStringToHsva = hsvaStringToHsva;
 
 export const rgbaStringToHsva = (rgbaString: string): HsvaColor => {
-  const matcher = /rgba?\((\d+),\s*(\d+),\s*(\d+),?\s*(\d+\.?\d*)?\)/;
+  const matcher = /rgba?\(?\s*(-?\d*\.?\d+)(%)?[,\s]+(-?\d*\.?\d+)(%)?[,\s]+(-?\d*\.?\d+)(%)?,?\s*[/\s]*(-?\d*\.?\d+)?(%)?\s*\)?/i;
   const match = matcher.exec(rgbaString);
 
   if (!match) return { h: 0, s: 0, v: 0, a: 1 };
 
   return rgbaToHsva({
-    r: Number(match[1]),
-    g: Number(match[2]),
-    b: Number(match[3]),
-    a: match[4] === undefined ? 1 : Number(match[4]),
+    r: Number(match[1]) / (match[2] ? 100 / 255 : 1),
+    g: Number(match[3]) / (match[4] ? 100 / 255 : 1),
+    b: Number(match[5]) / (match[6] ? 100 / 255 : 1),
+    a: match[7] === undefined ? 1 : Number(match[7]) / (match[8] ? 100 : 1),
   });
 };
 

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -86,8 +86,11 @@ it("Converts HSL string to HSVA", () => {
 });
 
 it("Converts HSLA string to HSVA", () => {
-  expect(hslaStringToHsva("hsla(0, 0%, 0%, 0.5)")).toMatchObject({ h: 0, s: 0, v: 0, a: 0.5 });
-  expect(hslaStringToHsva("hsla(200, 25%, 32%, 1)")).toMatchObject({ h: 200, s: 40, v: 40, a: 1 });
+  let test = (input, output) => expect(hslaStringToHsva(input)).toMatchObject(output);
+
+  test("hsla(0deg, 0%, 0%, 0.5)", { h: 0, s: 0, v: 0, a: 0.5 });
+  test("hsla(200, 25%, 32%, 1)", { h: 200, s: 40, v: 40, a: 1 });
+  test("hsla(.5turn 25% 32% / 50%)", { h: 180, s: 40, v: 40, a: 0.5 });
 });
 
 it("Converts HSVA to RGBA", () => {
@@ -106,6 +109,8 @@ it("Converts RGBA to HSVA", () => {
 it("Converts RGB string to HSVA", () => {
   expect(rgbStringToHsva("rgb(255, 255, 255)")).toMatchObject({ h: 0, s: 0, v: 100, a: 1 });
   expect(rgbStringToHsva("rgb(0,0,0)")).toMatchObject({ h: 0, s: 0, v: 0, a: 1 });
+  expect(rgbStringToHsva("rgb(100% 100% 100%)")).toMatchObject({ h: 0, s: 0, v: 100, a: 1 });
+  expect(rgbStringToHsva("rgb(50% 45.9% 25%)")).toMatchObject({ h: 50, s: 50, v: 50, a: 1 });
 });
 
 it("Converts HSVA to RGB string", () => {
@@ -121,6 +126,7 @@ it("Converts HSVA to RGBA string", () => {
 it("Converts RGBA string to HSVA", () => {
   let test = (input, output) => expect(rgbaStringToHsva(input)).toMatchObject(output);
   test("rgba(61, 88, 102, 0.5)", { h: 200, s: 40, v: 40, a: 0.5 });
+  test("rgba(23.9% 34.5% 40% / 99%)", { h: 200, s: 40, v: 40, a: 0.99 });
 });
 
 it("Converts HSVA to HSVA string", () => {
@@ -135,11 +141,16 @@ it("Converts HSVA to HSV string", () => {
 });
 
 it("Converts HSV string to HSVA", () => {
-  expect(hsvStringToHsva("hsv(0, 10.5%, 0%)")).toMatchObject({ h: 0, s: 11, v: 0, a: 1 });
+  expect(hsvStringToHsva("hsv(0, 11%, 0%)")).toMatchObject({ h: 0, s: 11, v: 0, a: 1 });
+  expect(hsvStringToHsva("hsv(90deg 20% 10%)")).toMatchObject({ h: 90, s: 20, v: 10, a: 1 });
+  expect(hsvStringToHsva("hsv(100grad 20% 10%)")).toMatchObject({ h: 90, s: 20, v: 10, a: 1 });
+  expect(hsvStringToHsva("hsv(0.25turn 20% 10%)")).toMatchObject({ h: 90, s: 20, v: 10, a: 1 });
+  expect(hsvStringToHsva("hsv(1.5708rad 20% 10%)")).toMatchObject({ h: 90, s: 20, v: 10, a: 1 });
 });
 
 it("Converts HSVA string to HSVA", () => {
-  expect(hsvaStringToHsva("hsva(0, 10.5%, 0, 0.5)")).toMatchObject({ h: 0, s: 11, v: 0, a: 0.5 });
+  expect(hsvaStringToHsva("hsva(0, 11%, 0, 0.5)")).toMatchObject({ h: 0, s: 11, v: 0, a: 0.5 });
+  expect(hsvStringToHsva("hsv(5deg 9% 7% / 40%)")).toMatchObject({ h: 5, s: 9, v: 7, a: 0.4 });
 });
 
 it("Rounds HSVA", () => {


### PR DESCRIPTION
Library's parsers were improved to support more CSS color formats and units.

```js
// percentage syntax
"rgb(100% 50% 25%)"

// deg, grad, rad, turn units
"hsla(100grad, 50%, 50%)"
"hsla(0.25turn, 50%, 50%)"

// modern slash-syntax is supported
"rgba(100% 50% 25% / 99%)"
"hsla(90 50% 50% / 10%)"

// optional leading zero is now supported
"hsla(.25turn, .9%, .5%, .25)"
```