### PR TITLE
Feat: string types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-colorful",
-  "version": "5.1.3",
+  "version": "5.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -12296,6 +12296,12 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
           "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
           "dev": true
+        },
+        "typescript": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+          "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+          "dev": true
         }
       }
     },
@@ -17810,9 +17816,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
-      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
+      "version": "4.3.1-rc",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.1-rc.tgz",
+      "integrity": "sha512-L3uJ0gcntaRaKni9aV2amYB+pCDVodKe/B5+IREyvtKGsDOF7cYjchHb/B894skqkgD52ykRuWatIZMqEsHIqA==",
       "dev": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "react-dom": "^17.0.0",
     "size-limit": "^4.10.1",
     "ts-jest": "^26.5.3",
-    "typescript": "^4.2.3",
+    "typescript": "^4.3.1-rc",
     "use-throttled-effect": "0.0.7"
   }
 }

--- a/src/components/HslStringColorPicker.tsx
+++ b/src/components/HslStringColorPicker.tsx
@@ -1,17 +1,17 @@
 import React from "react";
 
 import { ColorPicker } from "./common/ColorPicker";
-import { ColorModel, ColorPickerBaseProps } from "../types";
+import { ColorModel, ColorPickerBaseProps, HslStringColor } from "../types";
 import { equalColorString } from "../utils/compare";
 import { hslStringToHsva, hsvaToHslString } from "../utils/convert";
 
-const colorModel: ColorModel<string> = {
+const colorModel: ColorModel<HslStringColor> = {
   defaultColor: "hsl(0, 0%, 0%)",
   toHsva: hslStringToHsva,
   fromHsva: hsvaToHslString,
   equal: equalColorString,
 };
 
-export const HslStringColorPicker = (props: Partial<ColorPickerBaseProps<string>>): JSX.Element => (
-  <ColorPicker {...props} colorModel={colorModel} />
-);
+export const HslStringColorPicker = (
+  props: Partial<ColorPickerBaseProps<HslStringColor>>
+): JSX.Element => <ColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/HslaStringColorPicker.tsx
+++ b/src/components/HslaStringColorPicker.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 
 import { AlphaColorPicker } from "./common/AlphaColorPicker";
-import { ColorModel, ColorPickerBaseProps } from "../types";
+import { ColorModel, ColorPickerBaseProps, HslaStringColor } from "../types";
 import { equalColorString } from "../utils/compare";
 import { hslaStringToHsva, hsvaToHslaString } from "../utils/convert";
 
-const colorModel: ColorModel<string> = {
+const colorModel: ColorModel<HslaStringColor> = {
   defaultColor: "hsla(0, 0%, 0%, 1)",
   toHsva: hslaStringToHsva,
   fromHsva: hsvaToHslaString,
@@ -13,5 +13,5 @@ const colorModel: ColorModel<string> = {
 };
 
 export const HslaStringColorPicker = (
-  props: Partial<ColorPickerBaseProps<string>>
+  props: Partial<ColorPickerBaseProps<HslaStringColor>>
 ): JSX.Element => <AlphaColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/HsvStringColorPicker.tsx
+++ b/src/components/HsvStringColorPicker.tsx
@@ -1,17 +1,17 @@
 import React from "react";
 
 import { ColorPicker } from "./common/ColorPicker";
-import { ColorModel, ColorPickerBaseProps } from "../types";
+import { ColorModel, ColorPickerBaseProps, HsvStringColor } from "../types";
 import { equalColorString } from "../utils/compare";
 import { hsvStringToHsva, hsvaToHsvString } from "../utils/convert";
 
-const colorModel: ColorModel<string> = {
+const colorModel: ColorModel<HsvStringColor> = {
   defaultColor: "hsv(0, 0%, 0%)",
   toHsva: hsvStringToHsva,
   fromHsva: hsvaToHsvString,
   equal: equalColorString,
 };
 
-export const HsvStringColorPicker = (props: Partial<ColorPickerBaseProps<string>>): JSX.Element => (
-  <ColorPicker {...props} colorModel={colorModel} />
-);
+export const HsvStringColorPicker = (
+  props: Partial<ColorPickerBaseProps<HsvStringColor>>
+): JSX.Element => <ColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/HsvaStringColorPicker.tsx
+++ b/src/components/HsvaStringColorPicker.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 
 import { AlphaColorPicker } from "./common/AlphaColorPicker";
-import { ColorModel, ColorPickerBaseProps } from "../types";
+import { ColorModel, ColorPickerBaseProps, HsvaStringColor } from "../types";
 import { equalColorString } from "../utils/compare";
 import { hsvaStringToHsva, hsvaToHsvaString } from "../utils/convert";
 
-const colorModel: ColorModel<string> = {
+const colorModel: ColorModel<HsvaStringColor> = {
   defaultColor: "hsva(0, 0%, 0%, 1)",
   toHsva: hsvaStringToHsva,
   fromHsva: hsvaToHsvaString,
@@ -13,5 +13,5 @@ const colorModel: ColorModel<string> = {
 };
 
 export const HsvaStringColorPicker = (
-  props: Partial<ColorPickerBaseProps<string>>
+  props: Partial<ColorPickerBaseProps<HsvaStringColor>>
 ): JSX.Element => <AlphaColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/RgbStringColorPicker.tsx
+++ b/src/components/RgbStringColorPicker.tsx
@@ -1,17 +1,17 @@
 import React from "react";
 
 import { ColorPicker } from "./common/ColorPicker";
-import { ColorModel, ColorPickerBaseProps } from "../types";
+import { ColorModel, ColorPickerBaseProps, RgbStringColor } from "../types";
 import { equalColorString } from "../utils/compare";
 import { rgbStringToHsva, hsvaToRgbString } from "../utils/convert";
 
-const colorModel: ColorModel<string> = {
+const colorModel: ColorModel<RgbStringColor> = {
   defaultColor: "rgb(0, 0, 0)",
   toHsva: rgbStringToHsva,
   fromHsva: hsvaToRgbString,
   equal: equalColorString,
 };
 
-export const RgbStringColorPicker = (props: Partial<ColorPickerBaseProps<string>>): JSX.Element => (
-  <ColorPicker {...props} colorModel={colorModel} />
-);
+export const RgbStringColorPicker = (
+  props: Partial<ColorPickerBaseProps<RgbStringColor>>
+): JSX.Element => <ColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/RgbaStringColorPicker.tsx
+++ b/src/components/RgbaStringColorPicker.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 
 import { AlphaColorPicker } from "./common/AlphaColorPicker";
-import { ColorModel, ColorPickerBaseProps } from "../types";
+import { ColorModel, ColorPickerBaseProps, RgbaStringColor } from "../types";
 import { equalColorString } from "../utils/compare";
 import { rgbaStringToHsva, hsvaToRgbaString } from "../utils/convert";
 
-const colorModel: ColorModel<string> = {
+const colorModel: ColorModel<RgbaStringColor> = {
   defaultColor: "rgba(0, 0, 0, 1)",
   toHsva: rgbaStringToHsva,
   fromHsva: hsvaToRgbaString,
@@ -13,5 +13,5 @@ const colorModel: ColorModel<string> = {
 };
 
 export const RgbaStringColorPicker = (
-  props: Partial<ColorPickerBaseProps<string>>
+  props: Partial<ColorPickerBaseProps<RgbaStringColor>>
 ): JSX.Element => <AlphaColorPicker {...props} colorModel={colorModel} />;

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,20 @@ export { RgbStringColorPicker } from "./components/RgbStringColorPicker";
 export { HexColorInput } from "./components/HexColorInput";
 
 // Color model types
-export { RgbColor, RgbaColor, HslColor, HslaColor, HsvColor, HsvaColor } from "./types";
+export {
+  RgbColor,
+  RgbStringColor,
+  RgbaColor,
+  RgbaStringColor,
+  HslColor,
+  HslStringColor,
+  HslaColor,
+  HslaStringColor,
+  HsvColor,
+  HsvStringColor,
+  HsvaColor,
+  HsvaStringColor,
+} from "./types";
 
 // Tooling
 export { setNonce } from "./utils/nonce";

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,9 +6,13 @@ export interface RgbColor {
   b: number;
 }
 
+export type RgbStringColor = `rgb(${number}, ${number}, ${number})`;
+
 export interface RgbaColor extends RgbColor {
   a: number;
 }
+
+export type RgbaStringColor = `rgba(${number}, ${number}, ${number}, ${number})`;
 
 export interface HslColor {
   h: number;
@@ -16,9 +20,13 @@ export interface HslColor {
   l: number;
 }
 
+export type HslStringColor = `hsl(${number}, ${number}%, ${number}%)`;
+
 export interface HslaColor extends HslColor {
   a: number;
 }
+
+export type HslaStringColor = `hsla(${number}, ${number}%, ${number}%, ${number})`;
 
 export interface HsvColor {
   h: number;
@@ -26,13 +34,24 @@ export interface HsvColor {
   v: number;
 }
 
+export type HsvStringColor = `hsv(${number}, ${number}%, ${number}%)`;
+
 export interface HsvaColor extends HsvColor {
   a: number;
 }
 
-export type ObjectColor = RgbColor | HslColor | HsvColor | RgbaColor | HslaColor | HsvaColor;
+export type HsvaStringColor = `hsva(${number}, ${number}%, ${number}%, ${number})`;
 
-export type AnyColor = string | ObjectColor;
+export type ObjectColor = RgbColor | HslColor | HsvColor | RgbaColor | HslaColor | HsvaColor;
+export type StringColor =
+  | RgbStringColor
+  | HslStringColor
+  | HsvStringColor
+  | RgbaStringColor
+  | HslaStringColor
+  | HsvaStringColor;
+
+export type AnyColor = string | StringColor | ObjectColor;
 
 export interface ColorModel<T extends AnyColor> {
   defaultColor: T;

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -8,6 +8,10 @@ import {
   HsvColor,
   RgbStringColor,
   RgbaStringColor,
+  HsvStringColor,
+  HsvaStringColor,
+  HslStringColor,
+  HslaStringColor,
 } from "../types";
 
 /**
@@ -86,24 +90,24 @@ export const hsvaToHsla = ({ h, s, v, a }: HsvaColor): HslaColor => {
   };
 };
 
-export const hsvaToHslString = (hsva: HsvaColor): string => {
+export const hsvaToHslString = (hsva: HsvaColor): HslStringColor => {
   const { h, s, l } = hsvaToHsla(hsva);
   return `hsl(${h}, ${s}%, ${l}%)`;
 };
 
-export const hsvaToHsvString = (hsva: HsvaColor): string => {
+export const hsvaToHslaString = (hsva: HsvaColor): HslaStringColor => {
+  const { h, s, l, a } = hsvaToHsla(hsva);
+  return `hsla(${h}, ${s}%, ${l}%, ${a})`;
+};
+
+export const hsvaToHsvString = (hsva: HsvaColor): HsvStringColor => {
   const { h, s, v } = roundHsva(hsva);
   return `hsv(${h}, ${s}%, ${v}%)`;
 };
 
-export const hsvaToHsvaString = (hsva: HsvaColor): string => {
+export const hsvaToHsvaString = (hsva: HsvaColor): HsvaStringColor => {
   const { h, s, v, a } = roundHsva(hsva);
   return `hsva(${h}, ${s}%, ${v}%, ${a})`;
-};
-
-export const hsvaToHslaString = (hsva: HsvaColor): string => {
-  const { h, s, l, a } = hsvaToHsla(hsva);
-  return `hsla(${h}, ${s}%, ${l}%, ${a})`;
 };
 
 export const hsvaToRgba = ({ h, s, v, a }: HsvaColor): RgbaColor => {

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -1,5 +1,14 @@
 import { round } from "./round";
-import { RgbaColor, RgbColor, HslaColor, HslColor, HsvaColor, HsvColor } from "../types";
+import {
+  RgbaColor,
+  RgbColor,
+  HslaColor,
+  HslColor,
+  HsvaColor,
+  HsvColor,
+  RgbStringColor,
+  RgbaStringColor,
+} from "../types";
 
 /**
  * Valid CSS <angle> units.
@@ -116,12 +125,12 @@ export const hsvaToRgba = ({ h, s, v, a }: HsvaColor): RgbaColor => {
   };
 };
 
-export const hsvaToRgbString = (hsva: HsvaColor): string => {
+export const hsvaToRgbString = (hsva: HsvaColor): RgbStringColor => {
   const { r, g, b } = hsvaToRgba(hsva);
   return `rgb(${r}, ${g}, ${b})`;
 };
 
-export const hsvaToRgbaString = (hsva: HsvaColor): string => {
+export const hsvaToRgbaString = (hsva: HsvaColor): RgbaStringColor => {
   const { r, g, b, a } = hsvaToRgba(hsva);
   return `rgba(${r}, ${g}, ${b}, ${a})`;
 };


### PR DESCRIPTION
Not ready for merge before TS 4.3 finalizes (using the RC now) but template literal types are now really, really good and easy to use!

```
type RgbStringColor = `rgb(${number}, ${number}, ${number})`;

const color: RgbStringColor = "rgb(a, 0, 0)";
```

``[tsserver 2322] [E] Type '"rgb(a, 0, 0)"' is not assignable to type '`rgb(${number}, ${number}, ${number})`'.``

IMO, that's a super easy error to understand and helps a lot. 

Now, unfortunately we can't narrow down the number ranges (like 0-255) and hex strings are pretty much out of the question due to union type complexities (6 digit hex creates a union type of ~16.7 million possibilities, which the TS language server is very much not a fan of). ~~We could try something like `type HexDigit = number | string`, but I'm not sure how useful that would be. Maybe though, as it does narrow down the type somewhat.~~ Edit: Of course that won't work as you can't set fixed string lengths. Hex is a no-go.

At the very least, this can catch common typos in the string types, even if it's not as accurate as wished for. TS will immediately inform users they accidentally typed `rbg(0, 0, 0);` for example; they won't need to wait for the runtime regex to know of an error.