### PR TITLE
Use pointer events instead of mouse and touch events. Support multi touch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-colorful",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,6 +124,9 @@
       "\\.js$": "jest-esm-jsx-transform",
       "^.+\\.tsx?$": "ts-jest"
     },
+    "setupFilesAfterEnv": [
+      "./tests/setup.js"
+    ],
     "moduleNameMapper": {
       "\\.css$": "<rootDir>/tests/__mocks__/styles.css.mock.ts"
     }

--- a/src/components/common/Interactive.tsx
+++ b/src/components/common/Interactive.tsx
@@ -1,6 +1,5 @@
-import React, { useState, useRef, useCallback } from "react";
+import React, { useRef, useCallback } from "react";
 
-import { useIsomorphicLayoutEffect } from "../../hooks/useIsomorphicLayoutEffect";
 import { useEventCallback } from "../../hooks/useEventCallback";
 import { clamp } from "../../utils/clamp";
 
@@ -9,27 +8,14 @@ export interface Interaction {
   top: number;
 }
 
-// Check if an event was triggered by touch
-const isTouch = (event: MouseEvent | TouchEvent): event is TouchEvent => "touches" in event;
-
 // Returns a relative position of the pointer inside the node's bounding box
-const getRelativePosition = (node: HTMLDivElement, event: MouseEvent | TouchEvent): Interaction => {
+const getRelativePosition = (node: HTMLDivElement, event: PointerEvent): Interaction => {
   const rect = node.getBoundingClientRect();
 
-  // Get user's pointer position from `touches` array if it's a `TouchEvent`
-  const pointer = isTouch(event) ? event.touches[0] : (event as MouseEvent);
-
   return {
-    left: clamp((pointer.pageX - (rect.left + window.pageXOffset)) / rect.width),
-    top: clamp((pointer.pageY - (rect.top + window.pageYOffset)) / rect.height),
+    left: clamp((event.pageX - (rect.left + window.pageXOffset)) / rect.width),
+    top: clamp((event.pageY - (rect.top + window.pageYOffset)) / rect.height),
   };
-};
-
-// Browsers introduced an intervention, making touch events passive by default.
-// This workaround removes `preventDefault` call from the touch handlers.
-// https://github.com/facebook/react/issues/19651
-const preventDefaultMove = (event: MouseEvent | TouchEvent): void => {
-  !isTouch(event) && event.preventDefault();
 };
 
 interface Props {
@@ -40,57 +26,46 @@ interface Props {
 
 const InteractiveBase = ({ onMove, onKey, ...rest }: Props) => {
   const container = useRef<HTMLDivElement>(null);
-  const hasTouched = useRef(false);
-  const [isDragging, setDragging] = useState(false);
   const onMoveCallback = useEventCallback<Interaction>(onMove);
   const onKeyCallback = useEventCallback<Interaction>(onKey);
 
-  // Prevent mobile browsers from handling mouse events (conflicting with touch ones).
-  // If we detected a touch interaction before, we prefer reacting to touch events only.
-  const isValid = (event: MouseEvent | TouchEvent): boolean => {
-    if (hasTouched.current && !isTouch(event)) return false;
-    if (!hasTouched.current) hasTouched.current = isTouch(event);
-    return true;
-  };
-
   const handleMove = useCallback(
-    (event: MouseEvent | TouchEvent) => {
-      // Prevent text selection
-      preventDefaultMove(event);
-
-      // If user moves the pointer outside of the window or iframe bounds and release it there,
-      // `mouseup`/`touchend` won't be fired. In order to stop the picker from following the cursor
-      // after the user has moved the mouse/finger back to the document, we check `event.buttons`
-      // and `event.touches`. It allows us to detect that the user is just moving his pointer
-      // without pressing it down
-      const isDown = isTouch(event) ? event.touches.length > 0 : event.buttons > 0;
-
-      if (isDown && container.current) {
+    (event: PointerEvent) => {
+      if (container.current) {
         onMoveCallback(getRelativePosition(container.current, event));
-      } else {
-        setDragging(false);
       }
     },
     [onMoveCallback]
   );
 
+  const handleMoveEnd = useCallback(() => {
+    const el = container.current;
+    if (!el) {
+      return;
+    }
+    el.removeEventListener("pointermove", handleMove);
+    el.removeEventListener("pointerup", handleMoveEnd);
+  }, [handleMove]);
+
   const handleMoveStart = useCallback(
-    ({ nativeEvent }: React.MouseEvent | React.TouchEvent) => {
+    ({ nativeEvent }: React.PointerEvent) => {
       const el = container.current;
+      if (!el) {
+        return;
+      }
 
-      // Prevent text selection
-      preventDefaultMove(nativeEvent);
-
-      // Interrupt "mousedown" call on mobiles
-      if (!isValid(nativeEvent) || !el) return;
+      // testing-library doesn't have setPointerCapture implemented
+      el.setPointerCapture && el.setPointerCapture(nativeEvent.pointerId);
 
       // The node/ref must actually exist when user start an interaction.
       // We won't suppress the ESLint warning though, as it should probably be something to be aware of.
       el.focus();
       onMoveCallback(getRelativePosition(el, nativeEvent));
-      setDragging(true);
+
+      el.addEventListener("pointermove", handleMove);
+      el.addEventListener("pointerup", handleMoveEnd);
     },
-    [onMoveCallback]
+    [onMoveCallback, handleMove, handleMoveEnd]
   );
 
   const handleKeyDown = useCallback(
@@ -112,32 +87,12 @@ const InteractiveBase = ({ onMove, onKey, ...rest }: Props) => {
     [onKeyCallback]
   );
 
-  const handleMoveEnd = useCallback(() => setDragging(false), []);
-
-  const toggleDocumentEvents = useCallback(
-    (state) => {
-      // add or remove additional pointer event listeners
-      const toggleEvent = state ? window.addEventListener : window.removeEventListener;
-      toggleEvent(hasTouched.current ? "touchmove" : "mousemove", handleMove);
-      toggleEvent(hasTouched.current ? "touchend" : "mouseup", handleMoveEnd);
-    },
-    [handleMove, handleMoveEnd]
-  );
-
-  useIsomorphicLayoutEffect(() => {
-    toggleDocumentEvents(isDragging);
-    return () => {
-      isDragging && toggleDocumentEvents(false);
-    };
-  }, [isDragging, toggleDocumentEvents]);
-
   return (
     <div
       {...rest}
       className="react-colorful__interactive"
       ref={container}
-      onTouchStart={handleMoveStart}
-      onMouseDown={handleMoveStart}
+      onPointerDown={handleMoveStart}
       onKeyDown={handleKeyDown}
       tabIndex={0}
       role="slider"

--- a/src/components/common/Interactive.tsx
+++ b/src/components/common/Interactive.tsx
@@ -1,20 +1,29 @@
-import React, { useRef, useCallback } from "react";
+import React, { useRef, useMemo } from "react";
 
 import { useEventCallback } from "../../hooks/useEventCallback";
 import { clamp } from "../../utils/clamp";
-
+import { supportsPointerEvents } from "../../utils/supportsPointerEvents";
 export interface Interaction {
   left: number;
   top: number;
 }
 
+// Check if an event was triggered by touch
+const getPointer = (event: PointerEvent | TouchEvent): Touch | PointerEvent =>
+  supportsPointerEvents ? (event as PointerEvent) : (event as TouchEvent).touches[0];
+
 // Returns a relative position of the pointer inside the node's bounding box
-const getRelativePosition = (node: HTMLDivElement, event: PointerEvent): Interaction => {
+const getRelativePosition = (
+  node: HTMLDivElement,
+  event: PointerEvent | TouchEvent
+): Interaction => {
   const rect = node.getBoundingClientRect();
 
+  const pointer = getPointer(event);
+
   return {
-    left: clamp((event.pageX - (rect.left + window.pageXOffset)) / rect.width),
-    top: clamp((event.pageY - (rect.top + window.pageYOffset)) / rect.height),
+    left: clamp((pointer.pageX - (rect.left + window.pageXOffset)) / rect.width),
+    top: clamp((pointer.pageY - (rect.top + window.pageYOffset)) / rect.height),
   };
 };
 
@@ -29,47 +38,41 @@ const InteractiveBase = ({ onMove, onKey, ...rest }: Props) => {
   const onMoveCallback = useEventCallback<Interaction>(onMove);
   const onKeyCallback = useEventCallback<Interaction>(onKey);
 
-  const handleMove = useCallback(
-    (event: PointerEvent) => {
-      if (container.current) {
-        onMoveCallback(getRelativePosition(container.current, event));
-      }
-    },
-    [onMoveCallback]
-  );
-
-  const handleMoveEnd = useCallback(() => {
-    const el = container.current;
-    if (!el) {
-      return;
-    }
-    el.removeEventListener("pointermove", handleMove);
-    el.removeEventListener("pointerup", handleMoveEnd);
-  }, [handleMove]);
-
-  const handleMoveStart = useCallback(
-    ({ nativeEvent }: React.PointerEvent) => {
+  const [handleMoveStart, handleKeyDown] = useMemo(() => {
+    const handleMoveStart = ({ nativeEvent }: React.PointerEvent | React.TouchEvent) => {
       const el = container.current;
       if (!el) {
         return;
       }
 
-      // testing-library doesn't have setPointerCapture implemented
-      el.setPointerCapture && el.setPointerCapture(nativeEvent.pointerId);
+      // setPointerCapture is defined if and only if PointerEvent is supported
+      el.setPointerCapture && el.setPointerCapture((nativeEvent as PointerEvent).pointerId);
 
       // The node/ref must actually exist when user start an interaction.
       // We won't suppress the ESLint warning though, as it should probably be something to be aware of.
       el.focus();
       onMoveCallback(getRelativePosition(el, nativeEvent));
+      toggleDocumentEvents(true);
+    };
 
-      el.addEventListener("pointermove", handleMove);
-      el.addEventListener("pointerup", handleMoveEnd);
-    },
-    [onMoveCallback, handleMove, handleMoveEnd]
-  );
+    const handleMove = (event: PointerEvent | TouchEvent) => {
+      // If user moves the pointer outside of the window or iframe bounds and release it there,
+      // `mouseup`/`touchend` won't be fired. In order to stop the picker from following the cursor
+      // after the user has moved the mouse/finger back to the document, we check `event.buttons`
+      // and `event.touches`. It allows us to detect that the user is just moving his pointer
+      // without pressing it down
+      const isDown = !!getPointer(event);
 
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent) => {
+      if (isDown && container.current) {
+        onMoveCallback(getRelativePosition(container.current, event));
+      } else {
+        toggleDocumentEvents(false);
+      }
+    };
+
+    const handleMoveEnd = () => toggleDocumentEvents(false);
+
+    const handleKeyDown = (event: React.KeyboardEvent) => {
       const keyCode = event.which || event.keyCode;
 
       // Ignore all keys except arrow ones
@@ -83,16 +86,34 @@ const InteractiveBase = ({ onMove, onKey, ...rest }: Props) => {
         left: keyCode === 39 ? 0.05 : keyCode === 37 ? -0.05 : 0,
         top: keyCode === 40 ? 0.05 : keyCode === 38 ? -0.05 : 0,
       });
-    },
-    [onKeyCallback]
-  );
+    };
+
+    function toggleDocumentEvents(state: boolean) {
+      // add or remove additional pointer event listeners
+      const target = supportsPointerEvents ? container.current : window;
+      if (!target) return;
+      const toggleEvent = state ? target.addEventListener : target.removeEventListener;
+      toggleEvent(supportsPointerEvents ? "pointermove" : "touchmove", handleMove);
+      toggleEvent(supportsPointerEvents ? "pointerup" : "touchend", handleMoveEnd);
+    }
+
+    return [handleMoveStart, handleKeyDown];
+  }, []);
+
+  const handler = supportsPointerEvents
+    ? {
+        onPointerDown: handleMoveStart,
+      }
+    : {
+        onTouchStart: handleMoveStart,
+      };
 
   return (
     <div
       {...rest}
+      {...handler}
       className="react-colorful__interactive"
       ref={container}
-      onPointerDown={handleMoveStart}
       onKeyDown={handleKeyDown}
       tabIndex={0}
       role="slider"

--- a/src/hooks/useEventCallback.ts
+++ b/src/hooks/useEventCallback.ts
@@ -1,14 +1,15 @@
-import { useRef, useEffect, useCallback } from "react";
+import { useRef } from "react";
 
+function noop() {}
 // Saves incoming handler to the ref in order to avoid "useCallback hell"
 function useEventCallback<T>(handler?: (value: T) => void): (value: T) => void {
   const callbackRef = useRef(handler);
 
-  useEffect(() => {
+  if (callbackRef.current !== handler) {
     callbackRef.current = handler;
-  });
+  }
 
-  return useCallback((value: T) => callbackRef.current && callbackRef.current(value), []);
+  return callbackRef.current || noop;
 }
 
 export { useEventCallback };

--- a/src/hooks/useEventCallback.ts
+++ b/src/hooks/useEventCallback.ts
@@ -1,15 +1,17 @@
 import { useRef } from "react";
 
-function noop() {}
 // Saves incoming handler to the ref in order to avoid "useCallback hell"
 function useEventCallback<T>(handler?: (value: T) => void): (value: T) => void {
   const callbackRef = useRef(handler);
+  const fn = useRef((value: T) => {
+    callbackRef.current && callbackRef.current(value);
+  });
 
   if (callbackRef.current !== handler) {
     callbackRef.current = handler;
   }
 
-  return callbackRef.current || noop;
+  return fn.current;
 }
 
 export { useEventCallback };

--- a/src/utils/supportsPointerEvents.ts
+++ b/src/utils/supportsPointerEvents.ts
@@ -1,0 +1,1 @@
+export const supportsPointerEvents = "PointerEvent" in window;

--- a/tests/components.test.js
+++ b/tests/components.test.js
@@ -19,19 +19,6 @@ import {
 
 afterEach(cleanup);
 
-// Fix to pass `pageX` and `pageY`
-// See https://github.com/testing-library/react-testing-library/issues/268
-class FakeMouseEvent extends MouseEvent {
-  constructor(type, values = {}) {
-    super(type, { buttons: 1, bubbles: true, ...values });
-
-    Object.assign(this, {
-      pageX: values.pageX || 0,
-      pageY: values.pageY || 0,
-    });
-  }
-}
-
 // Mock `HTMLElement.getBoundingClientRect` to be able to read element sizes
 // See https://github.com/jsdom/jsdom/issues/135#issuecomment-68191941
 Object.defineProperties(HTMLElement.prototype, {
@@ -44,6 +31,25 @@ Object.defineProperties(HTMLElement.prototype, {
     }),
   },
 });
+
+// Testing-library doesn't support pageX and pageY by default.
+// Moreover for the pointer events it setup only isTrusted field
+// We can ovverride EventConstructor which is used in createEvent testing-library function:
+// https://github.com/testing-library/dom-testing-library/blob/75197fe09a85646a6ca1d877f5dde21da60e6b76/src/events.js#L21-L63
+// Also see this issue:
+// https://github.com/testing-library/dom-testing-library/issues/558
+const pointerEventCtorProps = ["pageX", "pageY"];
+export default class PointerEventFake extends Event {
+  constructor(type, props) {
+    super(type, props);
+    pointerEventCtorProps.forEach((prop) => {
+      if (props[prop] != null) {
+        this[prop] = props[prop];
+      }
+    });
+  }
+}
+window.PointerEvent = PointerEventFake;
 
 it("Renders proper color picker markup", () => {
   const result = render(<HexColorPicker color="#F00" />);
@@ -91,52 +97,35 @@ it("Doesn't call `onChange` when user changes a hue of a grayscale color", () =>
   const { container } = render(<HexColorPicker color="#000" onChange={handleChange} />);
   const hue = container.querySelector(".react-colorful__hue .react-colorful__interactive");
 
-  fireEvent.touchStart(hue, { touches: [{ pageX: 0, pageY: 0 }] });
-  fireEvent.touchMove(hue, { touches: [{ pageX: 100, pageY: 0 }] });
+  fireEvent.pointerDown(hue, { pageX: 0, pageY: 0 });
+  fireEvent.pointerMove(hue, { pageX: 100, pageY: 0 });
 
   expect(handleChange).not.toHaveBeenCalled();
 });
 
-it("Triggers `onChange` after a mouse interaction", async () => {
+it("Triggers `onChange` after a pointer interaction", async () => {
   const handleChange = jest.fn();
   const result = render(<RgbaColorPicker onChange={handleChange} />);
   const saturation = result.container.querySelector(
     ".react-colorful__saturation .react-colorful__interactive"
   );
 
-  fireEvent(saturation, new FakeMouseEvent("mousedown", { pageX: 0, pageY: 0 }));
-  fireEvent(saturation, new FakeMouseEvent("mousemove", { pageX: 10, pageY: 10 }));
+  fireEvent.pointerDown(saturation, { pageX: 0, pageY: 0 });
+  fireEvent.pointerMove(saturation, { pageX: 10, pageY: 10 });
 
   expect(handleChange).toHaveReturned();
 });
 
-it("Triggers `onChange` after a touch interaction", async () => {
+it("Triggers `onChange` after a pointer interaction", async () => {
   const handleChange = jest.fn((hex) => hex);
   const initialValue = { h: 0, s: 100, v: 100 };
   const result = render(<HsvColorPicker color={initialValue} onChange={handleChange} />);
   const hue = result.container.querySelector(".react-colorful__hue .react-colorful__interactive");
 
-  fireEvent.touchStart(hue, { touches: [{ pageX: 0, pageY: 0, bubbles: true }] });
-  fireEvent.touchMove(hue, { touches: [{ pageX: 55, pageY: 0, bubbles: true }] });
+  fireEvent.pointerDown(hue, { pageX: 0, pageY: 0 });
+  fireEvent.pointerMove(hue, { pageX: 55, pageY: 0 });
 
   expect(handleChange).toHaveReturnedWith({ h: 180, s: 100, v: 100 });
-});
-
-it("Pointer doesn't follow the mouse if it was released outside of the document bounds", async () => {
-  const handleChange = jest.fn();
-  const result = render(<RgbaColorPicker onChange={handleChange} />);
-  const saturation = result.container.querySelector(
-    ".react-colorful__saturation .react-colorful__interactive"
-  );
-
-  // User presses and moves the cursor inside the window
-  fireEvent(saturation, new FakeMouseEvent("mousedown", { pageX: 20, pageY: 10 })); // 1
-  fireEvent(saturation, new FakeMouseEvent("mousemove", { pageX: 10, pageY: 10 })); // 2
-  // User releases the mouse button outside of the document bounds with no `mouseup` event fired
-  // User moves the cursor back to the document with no button pressed
-  fireEvent(saturation, new FakeMouseEvent("mousemove", { pageX: 1, pageY: 50, buttons: 0 })); // 3
-
-  expect(handleChange).toHaveReturnedTimes(2); // the last `mousemove` has to be ignored
 });
 
 it("Changes alpha channel value after an interaction", async () => {
@@ -148,28 +137,10 @@ it("Changes alpha channel value after an interaction", async () => {
     ".react-colorful__alpha .react-colorful__interactive"
   );
 
-  fireEvent(alpha, new FakeMouseEvent("mousedown", { pageX: 0, pageY: 0 }));
-  fireEvent(alpha, new FakeMouseEvent("mousemove", { pageX: 105, pageY: 0 }));
+  fireEvent.pointerDown(alpha, { pageX: 0, pageY: 0 });
+  fireEvent.pointerMove(alpha, { pageX: 105, pageY: 0 });
 
   expect(handleChange).toHaveReturnedWith({ h: 100, s: 0, l: 0, a: 1 });
-});
-
-// Fast clicks on mobile devices
-// See https://github.com/omgovich/react-colorful/issues/55
-it("Doesn't react on mouse events after a touch interaction", () => {
-  const handleChange = jest.fn((hslString) => hslString);
-  const result = render(<HslStringColorPicker color="hsl(100, 0%, 0%)" onChange={handleChange} />);
-  const hue = result.container.querySelector(".react-colorful__hue .react-colorful__interactive");
-
-  fireEvent.touchStart(hue, { touches: [{ pageX: 0, pageY: 0, bubbles: true }] }); // 1
-  fireEvent.touchMove(hue, { touches: [{ pageX: 55, pageY: 0, bubbles: true }] }); // 2
-
-  // Should be skipped
-  fireEvent(hue, new FakeMouseEvent("mousedown", { pageX: 35, pageY: 0 })); // 3
-  fireEvent(hue, new FakeMouseEvent("mousemove", { pageX: 105, pageY: 0 })); // 4
-
-  expect(handleChange).toHaveReturnedTimes(2);
-  expect(handleChange).toHaveReturnedWith("hsl(180, 0%, 0%)");
 });
 
 it("Captures arrow keys only", async () => {
@@ -292,8 +263,8 @@ it("Sets proper `aria-valuetext` attribute value", async () => {
 
   expect(saturation.getAttribute("aria-valuetext")).toBe("Saturation 0%, Brightness 0%");
 
-  fireEvent(saturation, new FakeMouseEvent("mousedown", { pageX: 0, pageY: 0 }));
-  fireEvent(saturation, new FakeMouseEvent("mousemove", { pageX: 500, pageY: 0 })); // '#ff0000'
+  fireEvent.pointerDown(saturation, { pageX: 0, pageY: 0 });
+  fireEvent.pointerMove(saturation, { pageX: 500, pageY: 0 }); // '#ff0000'
 
   expect(saturation.getAttribute("aria-valuetext")).toBe("Saturation 100%, Brightness 100%");
 });

--- a/tests/components.test.js
+++ b/tests/components.test.js
@@ -8,7 +8,6 @@ import {
   RgbaColorPicker,
   RgbaStringColorPicker,
   HslColorPicker,
-  HslStringColorPicker,
   HslaColorPicker,
   HslaStringColorPicker,
   HsvColorPicker,

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -1,0 +1,4 @@
+jest.mock("../src/utils/supportsPointerEvents", () => ({
+  __esModule: true,
+  supportsPointerEvents: true,
+}));


### PR DESCRIPTION
Hey! Thanks for the library ;)

I was looking at the library after our Twitter discussion: https://twitter.com/Omgovich/status/1421136814954385418

## Overview

This pull request introduces several changes:

### Removed MouseEvent and TouchEvent in favor of PointerEvent. 

It has several advantages:

1) Smaller library size (about 170 bytes):

|Before|After|
|---|---|
| ![image](https://user-images.githubusercontent.com/1178825/127752345-e76fc4b1-780e-4746-9a81-3b3c1e885f5c.png) | ![image](https://user-images.githubusercontent.com/1178825/127752330-be4bfb0f-98fa-42cd-93f1-23179b190a38.png) |
| ![image](https://user-images.githubusercontent.com/1178825/127752357-39d94d53-7395-4d91-a361-80a788f72e4c.png) | ![image](https://user-images.githubusercontent.com/1178825/127752308-4899cb1a-1ce6-43bb-90ab-d2e7ddf8bf9f.png) |

2) We don't have browser hacks in code to preventDefault behavior and etc.

3) We don't need to resolve conflicts between touches and clicks. 

### Improved library performance 

1) I removed `useState`, which reduces component re-renders, 
2) got rid of excess `useEffects`  along with `useCallbacks` which also optimizes comparisons and overall performance

### Multi touch support

(sorry, didn't find a better way to attach the screencasts)

|Before|After|
|---|---|
|https://user-images.githubusercontent.com/1178825/127752546-d7169520-c6d8-4495-9ab4-5af16505edd5.MP4|https://user-images.githubusercontent.com/1178825/127752561-12864f6e-7cad-4a56-b3de-dd6b069eb568.MP4|


### Unit tests support

1) Removed unit test which no more needed 🙈

2) Added `PointerEvents` support


## What about browsers support?

It should work in all browsers including IE11: (and partly IE10): https://caniuse.com/pointer
![image](https://user-images.githubusercontent.com/1178825/127752700-02b16062-bbf0-4a18-a2df-24d02a37d34f.png)

Some screencasts:
Chrome: https://user-images.githubusercontent.com/1178825/127753055-25ba0bb7-8dd0-481d-8776-4f94bd0898a9.mp4

Firefox: https://user-images.githubusercontent.com/1178825/127752834-2da54a31-7c57-47a6-bfc8-3be510af0ace.mov 

IPhone safari: https://user-images.githubusercontent.com/1178825/127752561-12864f6e-7cad-4a56-b3de-dd6b069eb568.MP4