### PR TITLE
Optimize hooks, reduce library size and get rid of edge case errors and memory leaks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-colorful",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/common/Interactive.tsx
+++ b/src/components/common/Interactive.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useMemo } from "react";
+import React, { useRef, useMemo, useEffect } from "react";
 
 import { useEventCallback } from "../../hooks/useEventCallback";
 import { clamp } from "../../utils/clamp";
@@ -47,7 +47,7 @@ const InteractiveBase = ({ onMove, onKey, ...rest }: Props) => {
   const onKeyCallback = useEventCallback<Interaction>(onKey);
   const hasTouch = useRef(false);
 
-  const [handleMoveStart, handleKeyDown] = useMemo(() => {
+  const [handleMoveStart, handleKeyDown, toggleDocumentEvents] = useMemo(() => {
     const handleMoveStart = ({ nativeEvent }: React.MouseEvent | React.TouchEvent) => {
       const el = container.current;
       if (!el) {
@@ -103,7 +103,7 @@ const InteractiveBase = ({ onMove, onKey, ...rest }: Props) => {
       });
     };
 
-    function toggleDocumentEvents(state: boolean) {
+    function toggleDocumentEvents(state?: boolean) {
       const touch = hasTouch.current;
       // add or remove additional pointer event listeners
       const toggleEvent = state ? self.addEventListener : self.removeEventListener;
@@ -111,8 +111,9 @@ const InteractiveBase = ({ onMove, onKey, ...rest }: Props) => {
       toggleEvent(touch ? "touchend" : "mouseup", handleMoveEnd);
     }
 
-    return [handleMoveStart, handleKeyDown];
+    return [handleMoveStart, handleKeyDown, toggleDocumentEvents];
   }, []);
+  useEffect(() => toggleDocumentEvents, []);
 
   return (
     <div

--- a/src/components/common/Interactive.tsx
+++ b/src/components/common/Interactive.tsx
@@ -32,8 +32,9 @@ const preventDefaultMove = (event: MouseEvent | TouchEvent): void => {
 
 // Prevent mobile browsers from handling mouse events (conflicting with touch ones).
 // If we detected a touch interaction before, we prefer reacting to touch events only.
-const isInvalid = (event: MouseEvent | TouchEvent, hasTouch: boolean): boolean =>
-  hasTouch && !isTouch(event);
+const isInvalid = (event: MouseEvent | TouchEvent, hasTouch: boolean): boolean => {
+  return hasTouch && !isTouch(event);
+};
 
 interface Props {
   onMove: (interaction: Interaction) => void;
@@ -50,9 +51,7 @@ const InteractiveBase = ({ onMove, onKey, ...rest }: Props) => {
   const [handleMoveStart, handleKeyDown, toggleDocumentEvents] = useMemo(() => {
     const handleMoveStart = ({ nativeEvent }: React.MouseEvent | React.TouchEvent) => {
       const el = container.current;
-      if (!el) {
-        return;
-      }
+      if (!el) return;
 
       // Prevent text selection
       preventDefaultMove(nativeEvent);
@@ -112,8 +111,10 @@ const InteractiveBase = ({ onMove, onKey, ...rest }: Props) => {
     }
 
     return [handleMoveStart, handleKeyDown, toggleDocumentEvents];
-  }, []);
-  useEffect(() => toggleDocumentEvents, []);
+  }, [onKeyCallback, onMoveCallback]);
+
+  // Remove window event listeners before unmounting
+  useEffect(() => toggleDocumentEvents, [toggleDocumentEvents]);
 
   return (
     <div

--- a/src/hooks/useEventCallback.ts
+++ b/src/hooks/useEventCallback.ts
@@ -1,14 +1,12 @@
-import { useRef, useEffect, useCallback } from "react";
+import { useRef } from "react";
 
 // Saves incoming handler to the ref in order to avoid "useCallback hell"
-function useEventCallback<T>(handler?: (value: T) => void): (value: T) => void {
+export function useEventCallback<T>(handler?: (value: T) => void): (value: T) => void {
   const callbackRef = useRef(handler);
-
-  useEffect(() => {
-    callbackRef.current = handler;
+  const fn = useRef((value: T) => {
+    callbackRef.current && callbackRef.current(value);
   });
+  callbackRef.current = handler;
 
-  return useCallback((value: T) => callbackRef.current && callbackRef.current(value), []);
+  return fn.current;
 }
-
-export { useEventCallback };

--- a/tests/components.test.js
+++ b/tests/components.test.js
@@ -91,7 +91,9 @@ it("Doesn't call `onChange` when user changes a hue of a grayscale color", () =>
   const { container } = render(<HexColorPicker color="#000" onChange={handleChange} />);
   const hue = container.querySelector(".react-colorful__hue .react-colorful__interactive");
 
-  fireEvent.touchStart(hue, { touches: [{ pageX: 0, pageY: 0 }] });
+  fireEvent.touchStart(hue, {
+    touches: [{ pageX: 0, pageY: 0 }],
+  });
   fireEvent.touchMove(hue, { touches: [{ pageX: 100, pageY: 0 }] });
 
   expect(handleChange).not.toHaveBeenCalled();
@@ -116,7 +118,9 @@ it("Triggers `onChange` after a touch interaction", async () => {
   const result = render(<HsvColorPicker color={initialValue} onChange={handleChange} />);
   const hue = result.container.querySelector(".react-colorful__hue .react-colorful__interactive");
 
-  fireEvent.touchStart(hue, { touches: [{ pageX: 0, pageY: 0, bubbles: true }] });
+  fireEvent.touchStart(hue, {
+    touches: [{ pageX: 0, pageY: 0, bubbles: true }],
+  });
   fireEvent.touchMove(hue, { touches: [{ pageX: 55, pageY: 0, bubbles: true }] });
 
   expect(handleChange).toHaveReturnedWith({ h: 180, s: 100, v: 100 });
@@ -161,7 +165,9 @@ it("Doesn't react on mouse events after a touch interaction", () => {
   const result = render(<HslStringColorPicker color="hsl(100, 0%, 0%)" onChange={handleChange} />);
   const hue = result.container.querySelector(".react-colorful__hue .react-colorful__interactive");
 
-  fireEvent.touchStart(hue, { touches: [{ pageX: 0, pageY: 0, bubbles: true }] }); // 1
+  fireEvent.touchStart(hue, {
+    touches: [{ pageX: 0, pageY: 0, bubbles: true }],
+  }); // 1
   fireEvent.touchMove(hue, { touches: [{ pageX: 55, pageY: 0, bubbles: true }] }); // 2
 
   // Should be skipped


### PR DESCRIPTION
This diff makes the runtime faster and the library size smaller

|Before|After|
|---|---|
| ![image](https://user-images.githubusercontent.com/1178825/127752345-e76fc4b1-780e-4746-9a81-3b3c1e885f5c.png) | ![image](https://user-images.githubusercontent.com/1178825/128600170-5d286787-af47-409f-ad9d-997ef59a1b1d.png) |
| ![image](https://user-images.githubusercontent.com/1178825/127752357-39d94d53-7395-4d91-a361-80a788f72e4c.png) | ![image](https://user-images.githubusercontent.com/1178825/128600184-e9b3b1a7-504e-4b7e-be8b-b9c5dab09331.png) |

As we get rid of `useEffect` calls, it saves time in runtime. 

It also prevents us from the memory leak and potential errors


The behaviour isn't changed:

https://user-images.githubusercontent.com/1178825/128600229-9f30f0ae-5cf6-4c31-ae57-62cb17e3bdce.mov

