### PR TITLE
Support multitouch

### DIFF
--- a/tests/components.test.js
+++ b/tests/components.test.js
@@ -92,6 +92,7 @@ it("Doesn't call `onChange` when user changes a hue of a grayscale color", () =>
   const hue = container.querySelector(".react-colorful__hue .react-colorful__interactive");
 
   fireEvent.touchStart(hue, {
+    changedTouches: [{ pageX: 0, pageY: 0 }],
     touches: [{ pageX: 0, pageY: 0 }],
   });
   fireEvent.touchMove(hue, { touches: [{ pageX: 100, pageY: 0 }] });
@@ -119,6 +120,7 @@ it("Triggers `onChange` after a touch interaction", async () => {
   const hue = result.container.querySelector(".react-colorful__hue .react-colorful__interactive");
 
   fireEvent.touchStart(hue, {
+    changedTouches: [{ pageX: 0, pageY: 0 }],
     touches: [{ pageX: 0, pageY: 0, bubbles: true }],
   });
   fireEvent.touchMove(hue, { touches: [{ pageX: 55, pageY: 0, bubbles: true }] });
@@ -166,6 +168,7 @@ it("Doesn't react on mouse events after a touch interaction", () => {
   const hue = result.container.querySelector(".react-colorful__hue .react-colorful__interactive");
 
   fireEvent.touchStart(hue, {
+    changedTouches: [{ pageX: 0, pageY: 0 }],
     touches: [{ pageX: 0, pageY: 0, bubbles: true }],
   }); // 1
   fireEvent.touchMove(hue, { touches: [{ pageX: 55, pageY: 0, bubbles: true }] }); // 2


### PR DESCRIPTION
Demo:

https://user-images.githubusercontent.com/1178825/132987284-850713f0-0cbd-4368-8cca-a256f7f2a00b.MP4

Solution:
Each touch event has its own id. 
As we don't use pointer-events, we may preserve the touch id, which makes it's possible to bind the touch and the definite bar. 

The only downside is that the size was slightly increased because of the `getPoint` fn:
![image](https://user-images.githubusercontent.com/1178825/132987381-52381252-a2ae-4537-a2f4-e3bece31a171.png)



