### PR TITLE
Update ARIA attributes on ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
       "path": "dist/index.module.js",
       "name": "RgbaStringColorPicker",
       "import": "{ RgbaStringColorPicker }",
-      "limit": "3 KB"
+      "limit": "3.1 KB"
     },
     {
       "path": "dist/index.module.js",

--- a/src/components/common/Alpha.tsx
+++ b/src/components/common/Alpha.tsx
@@ -35,6 +35,7 @@ export const Alpha = ({ className, hsva, onChange }: Props): JSX.Element => {
   };
 
   const nodeClassName = formatClassName(["react-colorful__alpha", className]);
+  const ariaValue = round(hsva.a * 100);
 
   return (
     <div className={nodeClassName}>
@@ -43,7 +44,10 @@ export const Alpha = ({ className, hsva, onChange }: Props): JSX.Element => {
         onMove={handleMove}
         onKey={handleKey}
         aria-label="Alpha"
-        aria-valuetext={`${round(hsva.a * 100)}%`}
+        aria-valuetext={`${ariaValue}%`}
+        aria-valuenow={ariaValue}
+        aria-valuemin="0"
+        aria-valuemax="100"
       >
         <Pointer
           className="react-colorful__alpha-pointer"

--- a/src/components/common/Hue.tsx
+++ b/src/components/common/Hue.tsx
@@ -34,7 +34,9 @@ const HueBase = ({ className, hue, onChange }: Props) => {
         onMove={handleMove}
         onKey={handleKey}
         aria-label="Hue"
-        aria-valuetext={round(hue)}
+        aria-valuenow={round(hue)}
+        aria-valuemax="360"
+        aria-valuemin="0"
       >
         <Pointer
           className="react-colorful__hue-pointer"

--- a/tests/__snapshots__/components.test.js.snap
+++ b/tests/__snapshots__/components.test.js.snap
@@ -33,7 +33,9 @@ exports[`Accepts any valid \`div\` attributes 1`] = `
   >
     <div
       aria-label="Hue"
-      aria-valuetext="0"
+      aria-valuemax="360"
+      aria-valuemin="0"
+      aria-valuenow="0"
       class="react-colorful__interactive"
       role="slider"
       tabindex="0"
@@ -92,7 +94,9 @@ exports[`Renders proper alpha color picker markup 1`] = `
   >
     <div
       aria-label="Hue"
-      aria-valuetext="0"
+      aria-valuemax="360"
+      aria-valuemin="0"
+      aria-valuenow="0"
       class="react-colorful__interactive"
       role="slider"
       tabindex="0"
@@ -116,6 +120,9 @@ exports[`Renders proper alpha color picker markup 1`] = `
     />
     <div
       aria-label="Alpha"
+      aria-valuemax="100"
+      aria-valuemin="0"
+      aria-valuenow="50"
       aria-valuetext="50%"
       class="react-colorful__interactive"
       role="slider"
@@ -166,7 +173,9 @@ exports[`Renders proper color picker markup 1`] = `
   >
     <div
       aria-label="Hue"
-      aria-valuetext="0"
+      aria-valuemax="360"
+      aria-valuemin="0"
+      aria-valuenow="0"
       class="react-colorful__interactive"
       role="slider"
       tabindex="0"
@@ -216,7 +225,9 @@ exports[`Works with no props 1`] = `
   >
     <div
       aria-label="Hue"
-      aria-valuetext="0"
+      aria-valuemax="360"
+      aria-valuemin="0"
+      aria-valuenow="0"
       class="react-colorful__interactive"
       role="slider"
       tabindex="0"

--- a/tests/components.test.js
+++ b/tests/components.test.js
@@ -340,7 +340,7 @@ it("Sets proper `aria-valuetext` attribute value", async () => {
 });
 
 it("Accepts any valid `div` attributes", () => {
-  const result = render(<HexColorPicker id="my-id" aria-hidden="false" />);
+  const result = render(<RgbStringColorPicker id="my-id" aria-hidden="false" />);
 
   expect(result.container.firstChild).toMatchSnapshot();
 });

--- a/tests/components.test.js
+++ b/tests/components.test.js
@@ -319,17 +319,24 @@ it("Ignores keyboard commands if the pointer is already on a alpha edge", async 
 
 it("Sets proper `aria-valuetext` attribute value", async () => {
   const handleChange = jest.fn();
-  const result = render(<RgbStringColorPicker color="rgb(0, 0, 0)" onChange={handleChange} />);
+  const result = render(<RgbaStringColorPicker color="rgb(0, 0, 0, 0)" onChange={handleChange} />);
   const saturation = result.container.querySelector(
     ".react-colorful__saturation .react-colorful__interactive"
   );
+  const alpha = result.container.querySelector(
+    ".react-colorful__alpha .react-colorful__interactive"
+  );
 
   expect(saturation.getAttribute("aria-valuetext")).toBe("Saturation 0%, Brightness 0%");
+  expect(alpha.getAttribute("aria-valuetext")).toBe("0%");
 
   fireEvent(saturation, new FakeMouseEvent("mousedown", { pageX: 0, pageY: 0 }));
   fireEvent(saturation, new FakeMouseEvent("mousemove", { pageX: 500, pageY: 0 })); // '#ff0000'
+  fireEvent(alpha, new FakeMouseEvent("mousedown", { pageX: 0, pageY: 0 }));
+  fireEvent(alpha, new FakeMouseEvent("mousemove", { pageX: 500, pageY: 0 }));
 
   expect(saturation.getAttribute("aria-valuetext")).toBe("Saturation 100%, Brightness 100%");
+  expect(alpha.getAttribute("aria-valuetext")).toBe("100%");
 });
 
 it("Accepts any valid `div` attributes", () => {


### PR DESCRIPTION
Fixes https://github.com/omgovich/react-colorful/issues/171

## In the `Hue` component:

- `aria-valuetext` has been changed to `aria-valuenow`. Since the "human understandable" value is numeric, we don't need both `valuetext` and `valuenow`, and `valuenow` is the "required" attribute
- `aria-valuemin` has been set to 0 and `aria-valuemax` has been set to 360 to provide a bit more context for screen reader users

## In the `Alpha` component:

- `aria-valuenow` has been added. This is **in addition** to `aria-valuetext`. Screen readers will generally read out the more understandable `valuetext`, but `valuenow` is a required attribute to accompany it
- `aria-valuemin` has been set to 0 and `aria-valuemax` has been set to 100

## In the `Saturation` component:

No change has been made! I don't believe there is an available numeric representation of the current value, so in this case I believe we can omit `aria-valuenow` for the time being until https://github.com/omgovich/react-colorful/issues/152 is addressed.


Snapshot tests have been updated to reflect the new attributes 🙂 

Check out the [docs for `aria-valuenow`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-valuenow) for more context