### PR TITLE
Use `substring` instead of deprecated `substr`.

### DIFF
--- a/src/components/HexColorInput.tsx
+++ b/src/components/HexColorInput.tsx
@@ -19,7 +19,7 @@ export const HexColorInput = (props: HexColorInputProps): JSX.Element => {
 
   /** Escapes all non-hexadecimal characters including "#" */
   const escape = useCallback(
-    (value: string) => value.replace(/([^0-9A-F]+)/gi, "").substr(0, alpha ? 8 : 6),
+    (value: string) => value.replace(/([^0-9A-F]+)/gi, "").substring(0, alpha ? 8 : 6),
     [alpha]
   );
 

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -14,7 +14,7 @@ const angleUnits: Record<string, number> = {
 export const hexToHsva = (hex: string): HsvaColor => rgbaToHsva(hexToRgba(hex));
 
 export const hexToRgba = (hex: string): RgbaColor => {
-  if (hex[0] === "#") hex = hex.substr(1);
+  if (hex[0] === "#") hex = hex.substring(1);
 
   if (hex.length < 6) {
     return {
@@ -26,9 +26,9 @@ export const hexToRgba = (hex: string): RgbaColor => {
   }
 
   return {
-    r: parseInt(hex.substr(0, 2), 16),
-    g: parseInt(hex.substr(2, 2), 16),
-    b: parseInt(hex.substr(4, 2), 16),
+    r: parseInt(hex.substring(0, 2), 16),
+    g: parseInt(hex.substring(2, 4), 16),
+    b: parseInt(hex.substring(4, 6), 16),
     a: 1,
   };
 };


### PR DESCRIPTION
Removes the `substr` method, as it's deprecated:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr