### PR TITLE
Fix RGBA calc error when change alpha

### DIFF
--- a/src/components/HexAlphaColorPicker.tsx
+++ b/src/components/HexAlphaColorPicker.tsx
@@ -3,13 +3,14 @@ import React from "react";
 import { AlphaColorPicker } from "./common/AlphaColorPicker";
 import { ColorModel, ColorPickerBaseProps } from "../types";
 import { equalHex } from "../utils/compare";
-import { hexToHsva, hsvaToHex } from "../utils/convert";
+import { hexToHsva, hsvaToHex, updateAlphaFromString } from "../utils/convert";
 
 const colorModel: ColorModel<string> = {
   defaultColor: "0001",
   toHsva: hexToHsva,
   fromHsva: hsvaToHex,
   equal: equalHex,
+  updateAlpha: updateAlphaFromString,
 };
 
 export const HexAlphaColorPicker = (props: Partial<ColorPickerBaseProps<string>>): JSX.Element => (

--- a/src/components/HslaColorPicker.tsx
+++ b/src/components/HslaColorPicker.tsx
@@ -3,14 +3,14 @@ import React from "react";
 import { AlphaColorPicker } from "./common/AlphaColorPicker";
 import { ColorModel, ColorPickerBaseProps, HslaColor } from "../types";
 import { equalColorObjects } from "../utils/compare";
-import { hslaToHsva, hsvaToHsla, updateAlphaFromHsla } from "../utils/convert";
+import { hslaToHsva, hsvaToHsla, updateAlphaFromObject } from "../utils/convert";
 
 const colorModel: ColorModel<HslaColor> = {
   defaultColor: { h: 0, s: 0, l: 0, a: 1 },
   toHsva: hslaToHsva,
   fromHsva: hsvaToHsla,
   equal: equalColorObjects,
-  updateAlpha: updateAlphaFromHsla,
+  updateAlpha: updateAlphaFromObject,
 };
 
 export const HslaColorPicker = (props: Partial<ColorPickerBaseProps<HslaColor>>): JSX.Element => (

--- a/src/components/HslaColorPicker.tsx
+++ b/src/components/HslaColorPicker.tsx
@@ -3,14 +3,14 @@ import React from "react";
 import { AlphaColorPicker } from "./common/AlphaColorPicker";
 import { ColorModel, ColorPickerBaseProps, HslaColor } from "../types";
 import { equalColorObjects } from "../utils/compare";
-import { hslaToHsva, hsvaToHsla, updateAlphaFromObject } from "../utils/convert";
+import { hslaToHsva, hsvaToHsla, updateAlphaFromHsla } from "../utils/convert";
 
 const colorModel: ColorModel<HslaColor> = {
   defaultColor: { h: 0, s: 0, l: 0, a: 1 },
   toHsva: hslaToHsva,
   fromHsva: hsvaToHsla,
   equal: equalColorObjects,
-  updateAlpha: updateAlphaFromObject,
+  updateAlpha: updateAlphaFromHsla,
 };
 
 export const HslaColorPicker = (props: Partial<ColorPickerBaseProps<HslaColor>>): JSX.Element => (

--- a/src/components/HslaColorPicker.tsx
+++ b/src/components/HslaColorPicker.tsx
@@ -3,13 +3,14 @@ import React from "react";
 import { AlphaColorPicker } from "./common/AlphaColorPicker";
 import { ColorModel, ColorPickerBaseProps, HslaColor } from "../types";
 import { equalColorObjects } from "../utils/compare";
-import { hslaToHsva, hsvaToHsla } from "../utils/convert";
+import { hslaToHsva, hsvaToHsla, updateAlphaFromObject } from "../utils/convert";
 
 const colorModel: ColorModel<HslaColor> = {
   defaultColor: { h: 0, s: 0, l: 0, a: 1 },
   toHsva: hslaToHsva,
   fromHsva: hsvaToHsla,
   equal: equalColorObjects,
+  updateAlpha: updateAlphaFromObject,
 };
 
 export const HslaColorPicker = (props: Partial<ColorPickerBaseProps<HslaColor>>): JSX.Element => (

--- a/src/components/HslaStringColorPicker.tsx
+++ b/src/components/HslaStringColorPicker.tsx
@@ -3,13 +3,14 @@ import React from "react";
 import { AlphaColorPicker } from "./common/AlphaColorPicker";
 import { ColorModel, ColorPickerBaseProps } from "../types";
 import { equalColorString } from "../utils/compare";
-import { hslaStringToHsva, hsvaToHslaString } from "../utils/convert";
+import { hslaStringToHsva, hsvaToHslaString, updateAlphaFromString } from "../utils/convert";
 
 const colorModel: ColorModel<string> = {
   defaultColor: "hsla(0, 0%, 0%, 1)",
   toHsva: hslaStringToHsva,
   fromHsva: hsvaToHslaString,
   equal: equalColorString,
+  updateAlpha: updateAlphaFromString,
 };
 
 export const HslaStringColorPicker = (

--- a/src/components/HsvaColorPicker.tsx
+++ b/src/components/HsvaColorPicker.tsx
@@ -3,14 +3,14 @@ import React from "react";
 import { AlphaColorPicker } from "./common/AlphaColorPicker";
 import { ColorModel, ColorPickerBaseProps, HsvaColor } from "../types";
 import { equalColorObjects } from "../utils/compare";
-import { roundHsva, updateAlphaFromObject } from "../utils/convert";
+import { roundHsva, updateAlphaFromHsva } from "../utils/convert";
 
 const colorModel: ColorModel<HsvaColor> = {
   defaultColor: { h: 0, s: 0, v: 0, a: 1 },
   toHsva: (hsva) => hsva,
   fromHsva: roundHsva,
   equal: equalColorObjects,
-  updateAlpha: updateAlphaFromObject,
+  updateAlpha: updateAlphaFromHsva,
 };
 
 export const HsvaColorPicker = (props: Partial<ColorPickerBaseProps<HsvaColor>>): JSX.Element => (

--- a/src/components/HsvaColorPicker.tsx
+++ b/src/components/HsvaColorPicker.tsx
@@ -3,13 +3,14 @@ import React from "react";
 import { AlphaColorPicker } from "./common/AlphaColorPicker";
 import { ColorModel, ColorPickerBaseProps, HsvaColor } from "../types";
 import { equalColorObjects } from "../utils/compare";
-import { roundHsva } from "../utils/convert";
+import { roundHsva, updateAlphaFromObject } from "../utils/convert";
 
 const colorModel: ColorModel<HsvaColor> = {
   defaultColor: { h: 0, s: 0, v: 0, a: 1 },
   toHsva: (hsva) => hsva,
   fromHsva: roundHsva,
   equal: equalColorObjects,
+  updateAlpha: updateAlphaFromObject,
 };
 
 export const HsvaColorPicker = (props: Partial<ColorPickerBaseProps<HsvaColor>>): JSX.Element => (

--- a/src/components/HsvaColorPicker.tsx
+++ b/src/components/HsvaColorPicker.tsx
@@ -3,14 +3,14 @@ import React from "react";
 import { AlphaColorPicker } from "./common/AlphaColorPicker";
 import { ColorModel, ColorPickerBaseProps, HsvaColor } from "../types";
 import { equalColorObjects } from "../utils/compare";
-import { roundHsva, updateAlphaFromHsva } from "../utils/convert";
+import { roundHsva, updateAlphaFromObject } from "../utils/convert";
 
 const colorModel: ColorModel<HsvaColor> = {
   defaultColor: { h: 0, s: 0, v: 0, a: 1 },
   toHsva: (hsva) => hsva,
   fromHsva: roundHsva,
   equal: equalColorObjects,
-  updateAlpha: updateAlphaFromHsva,
+  updateAlpha: updateAlphaFromObject,
 };
 
 export const HsvaColorPicker = (props: Partial<ColorPickerBaseProps<HsvaColor>>): JSX.Element => (

--- a/src/components/HsvaStringColorPicker.tsx
+++ b/src/components/HsvaStringColorPicker.tsx
@@ -3,13 +3,14 @@ import React from "react";
 import { AlphaColorPicker } from "./common/AlphaColorPicker";
 import { ColorModel, ColorPickerBaseProps } from "../types";
 import { equalColorString } from "../utils/compare";
-import { hsvaStringToHsva, hsvaToHsvaString } from "../utils/convert";
+import { hsvaStringToHsva, hsvaToHsvaString, updateAlphaFromString } from "../utils/convert";
 
 const colorModel: ColorModel<string> = {
   defaultColor: "hsva(0, 0%, 0%, 1)",
   toHsva: hsvaStringToHsva,
   fromHsva: hsvaToHsvaString,
   equal: equalColorString,
+  updateAlpha: updateAlphaFromString,
 };
 
 export const HsvaStringColorPicker = (

--- a/src/components/RgbaColorPicker.tsx
+++ b/src/components/RgbaColorPicker.tsx
@@ -3,14 +3,14 @@ import React from "react";
 import { AlphaColorPicker } from "./common/AlphaColorPicker";
 import { ColorModel, ColorPickerBaseProps, RgbaColor } from "../types";
 import { equalColorObjects } from "../utils/compare";
-import { rgbaToHsva, hsvaToRgba, updateAlphaFromObject } from "../utils/convert";
+import { rgbaToHsva, hsvaToRgba, updateAlphaFromRgba } from "../utils/convert";
 
 const colorModel: ColorModel<RgbaColor> = {
   defaultColor: { r: 0, g: 0, b: 0, a: 1 },
   toHsva: rgbaToHsva,
   fromHsva: hsvaToRgba,
   equal: equalColorObjects,
-  updateAlpha: updateAlphaFromObject,
+  updateAlpha: updateAlphaFromRgba,
 };
 
 export const RgbaColorPicker = (props: Partial<ColorPickerBaseProps<RgbaColor>>): JSX.Element => (

--- a/src/components/RgbaColorPicker.tsx
+++ b/src/components/RgbaColorPicker.tsx
@@ -3,13 +3,14 @@ import React from "react";
 import { AlphaColorPicker } from "./common/AlphaColorPicker";
 import { ColorModel, ColorPickerBaseProps, RgbaColor } from "../types";
 import { equalColorObjects } from "../utils/compare";
-import { rgbaToHsva, hsvaToRgba } from "../utils/convert";
+import { rgbaToHsva, hsvaToRgba, updateAlphaFromObject } from "../utils/convert";
 
 const colorModel: ColorModel<RgbaColor> = {
   defaultColor: { r: 0, g: 0, b: 0, a: 1 },
   toHsva: rgbaToHsva,
   fromHsva: hsvaToRgba,
   equal: equalColorObjects,
+  updateAlpha: updateAlphaFromObject,
 };
 
 export const RgbaColorPicker = (props: Partial<ColorPickerBaseProps<RgbaColor>>): JSX.Element => (

--- a/src/components/RgbaColorPicker.tsx
+++ b/src/components/RgbaColorPicker.tsx
@@ -3,14 +3,14 @@ import React from "react";
 import { AlphaColorPicker } from "./common/AlphaColorPicker";
 import { ColorModel, ColorPickerBaseProps, RgbaColor } from "../types";
 import { equalColorObjects } from "../utils/compare";
-import { rgbaToHsva, hsvaToRgba, updateAlphaFromRgba } from "../utils/convert";
+import { rgbaToHsva, hsvaToRgba, updateAlphaFromObject } from "../utils/convert";
 
 const colorModel: ColorModel<RgbaColor> = {
   defaultColor: { r: 0, g: 0, b: 0, a: 1 },
   toHsva: rgbaToHsva,
   fromHsva: hsvaToRgba,
   equal: equalColorObjects,
-  updateAlpha: updateAlphaFromRgba,
+  updateAlpha: updateAlphaFromObject,
 };
 
 export const RgbaColorPicker = (props: Partial<ColorPickerBaseProps<RgbaColor>>): JSX.Element => (

--- a/src/components/RgbaStringColorPicker.tsx
+++ b/src/components/RgbaStringColorPicker.tsx
@@ -3,13 +3,14 @@ import React from "react";
 import { AlphaColorPicker } from "./common/AlphaColorPicker";
 import { ColorModel, ColorPickerBaseProps } from "../types";
 import { equalColorString } from "../utils/compare";
-import { rgbaStringToHsva, hsvaToRgbaString } from "../utils/convert";
+import { rgbaStringToHsva, hsvaToRgbaString, updateAlphaFromString } from "../utils/convert";
 
 const colorModel: ColorModel<string> = {
   defaultColor: "rgba(0, 0, 0, 1)",
   toHsva: rgbaStringToHsva,
   fromHsva: hsvaToRgbaString,
   equal: equalColorString,
+  updateAlpha: updateAlphaFromString,
 };
 
 export const RgbaStringColorPicker = (

--- a/src/hooks/useColorManipulation.ts
+++ b/src/hooks/useColorManipulation.ts
@@ -36,11 +36,9 @@ export function useColorManipulation<T extends AnyColor>(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { a: _, ...cacheHsv } = cache.current.hsva;
 
-    const isSupportAlpha = "updateAlpha" in colorModel;
-
     // When alpha channel is changed, use cached RGB values to prevent rounding errors
     const newColor = equalColorObjects(hsv, cacheHsv)
-      ? isSupportAlpha
+      ? colorModel.updateAlpha
         ? colorModel.updateAlpha(cache.current.color, a)
         : cache.current.color
       : colorModel.fromHsva(hsva);

--- a/src/hooks/useColorManipulation.ts
+++ b/src/hooks/useColorManipulation.ts
@@ -32,10 +32,18 @@ export function useColorManipulation<T extends AnyColor>(
   // Trigger `onChange` callback only if an updated color is different from cached one;
   // save the new color to the ref to prevent unnecessary updates
   useEffect(() => {
-    let newColor;
+    const { a, ...hsv } = hsva;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { a: _, ...cacheHsv } = cache.current.hsva;
+
+    // When alpha channel is changed, use cached RGB values to prevent rounding errors
+    const newColor = equalColorObjects(hsv, cacheHsv)
+      ? Object.assign({}, cache.current.color, { a })
+      : colorModel.fromHsva(hsva);
+
     if (
       !equalColorObjects(hsva, cache.current.hsva) &&
-      !colorModel.equal((newColor = colorModel.fromHsva(hsva)), cache.current.color)
+      !colorModel.equal(newColor, cache.current.color)
     ) {
       cache.current = { hsva, color: newColor };
       onChangeCallback(newColor);

--- a/src/hooks/useColorManipulation.ts
+++ b/src/hooks/useColorManipulation.ts
@@ -36,9 +36,13 @@ export function useColorManipulation<T extends AnyColor>(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { a: _, ...cacheHsv } = cache.current.hsva;
 
+    const isSupportAlpha = "updateAlpha" in colorModel;
+
     // When alpha channel is changed, use cached RGB values to prevent rounding errors
     const newColor = equalColorObjects(hsv, cacheHsv)
-      ? Object.assign({}, cache.current.color, { a })
+      ? isSupportAlpha
+        ? colorModel.updateAlpha(cache.current.color, a)
+        : cache.current.color
       : colorModel.fromHsva(hsva);
 
     if (

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,9 @@ export interface ColorModel<T extends AnyColor> {
   toHsva: (defaultColor: T) => HsvaColor;
   fromHsva: (hsva: HsvaColor) => T;
   equal: (first: T, second: T) => boolean;
+  updateAlpha?:
+    | ((color: string, alpha: number) => string)
+    | ((color: ObjectColor, alpha: number) => ObjectColor);
 }
 
 type ColorPickerHTMLAttributes = Omit<

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,9 +39,7 @@ export interface ColorModel<T extends AnyColor> {
   toHsva: (defaultColor: T) => HsvaColor;
   fromHsva: (hsva: HsvaColor) => T;
   equal: (first: T, second: T) => boolean;
-  updateAlpha?:
-    | ((color: string, alpha: number) => string)
-    | ((color: ObjectColor, alpha: number) => ObjectColor);
+  updateAlpha?: (color: T, alpha: number) => T;
 }
 
 type ColorPickerHTMLAttributes = Omit<

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -209,14 +209,9 @@ export const updateAlphaFromString = (color: string, alpha: number): string => {
   return color.replace(/\d+\.\d+\)/, `${alpha})`);
 };
 
-export const updateAlphaFromHsla = (color: HslaColor, alpha: number): HslaColor => {
-  return Object.assign({}, color, { a: alpha });
-};
-
-export const updateAlphaFromHsva = (color: HsvaColor, alpha: number): HsvaColor => {
-  return Object.assign({}, color, { a: alpha });
-};
-
-export const updateAlphaFromRgba = (color: RgbaColor, alpha: number): RgbaColor => {
+export const updateAlphaFromObject = <T extends RgbaColor | HslaColor | HsvaColor>(
+  color: T,
+  alpha: number
+): T => {
   return Object.assign({}, color, { a: alpha });
 };

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -1,5 +1,13 @@
 import { round } from "./round";
-import { RgbaColor, RgbColor, HslaColor, HslColor, HsvaColor, HsvColor } from "../types";
+import {
+  RgbaColor,
+  RgbColor,
+  HslaColor,
+  HslColor,
+  HsvaColor,
+  HsvColor,
+  ObjectColor,
+} from "../types";
 
 /**
  * Valid CSS <angle> units.
@@ -203,4 +211,12 @@ export const hslaToHsl = ({ h, s, l }: HslaColor): HslColor => ({ h, s, l });
 export const hsvaToHsv = (hsva: HsvaColor): HsvColor => {
   const { h, s, v } = roundHsva(hsva);
   return { h, s, v };
+};
+
+export const updateAlphaFromString = (color: string, alpha: number): string => {
+  return color.replace(/\d+\.\d+\)/, `${alpha})`);
+};
+
+export const updateAlphaFromObject = (color: ObjectColor, alpha: number): ObjectColor => {
+  return Object.assign({}, color, { a: alpha });
 };

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -1,13 +1,5 @@
 import { round } from "./round";
-import {
-  RgbaColor,
-  RgbColor,
-  HslaColor,
-  HslColor,
-  HsvaColor,
-  HsvColor,
-  ObjectColor,
-} from "../types";
+import { RgbaColor, RgbColor, HslaColor, HslColor, HsvaColor, HsvColor } from "../types";
 
 /**
  * Valid CSS <angle> units.
@@ -217,6 +209,14 @@ export const updateAlphaFromString = (color: string, alpha: number): string => {
   return color.replace(/\d+\.\d+\)/, `${alpha})`);
 };
 
-export const updateAlphaFromObject = (color: ObjectColor, alpha: number): ObjectColor => {
+export const updateAlphaFromHsla = (color: HslaColor, alpha: number): HslaColor => {
+  return Object.assign({}, color, { a: alpha });
+};
+
+export const updateAlphaFromHsva = (color: HsvaColor, alpha: number): HsvaColor => {
+  return Object.assign({}, color, { a: alpha });
+};
+
+export const updateAlphaFromRgba = (color: RgbaColor, alpha: number): RgbaColor => {
   return Object.assign({}, color, { a: alpha });
 };


### PR DESCRIPTION
Fix: #163

I believe this error is due to an unavoidable rounding error in the process of inter-converting RGB and HSV with integer values.
However, I thought this error would be avoided by retaining the cached RGB values when the alpha value is changed.

I don't know if this change is sufficient, but it appears to have worked correctly for me.
I hope this will be helpful to fix the problem.