### PR TITLE
Added ColorPickerBaseProps modal types to use

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export { RgbStringColorPicker } from "./components/RgbStringColorPicker";
 export { HexColorInput } from "./components/HexColorInput";
 
 // Color model types
-export { RgbColor, RgbaColor, HslColor, HslaColor, HsvColor, HsvaColor } from "./types";
+export { RgbColor, RgbaColor, HslColor, HslaColor, HsvColor, HsvaColor, ColorPickerBaseProps } from "./types";
 
 // Tooling
 export { setNonce } from "./utils/nonce";


### PR DESCRIPTION
It's issue #217. The problem is this: If someone wants to have a custom component, they don't know the props to pass it. In the types folder, we have an interface named ColorPickerBaseProps, but we didn't import it to use for props to know what the props type is. Only I exported this interface beside their type to be able to use it.

![image](https://github.com/user-attachments/assets/c4e8efc4-d5f2-4c36-8ae0-ac45b6ba1609)
![image](https://github.com/user-attachments/assets/58c862c5-e1fa-4747-a23c-f72c99c12255)
![image](https://github.com/user-attachments/assets/ddb48cf6-2f0b-49a6-990d-5005184aa12b)
