### PR TITLE
Fix React 19 type compatibility

### DIFF
--- a/src/components/HexAlphaColorPicker.tsx
+++ b/src/components/HexAlphaColorPicker.tsx
@@ -12,6 +12,6 @@ const colorModel: ColorModel<string> = {
   equal: equalHex,
 };
 
-export const HexAlphaColorPicker = (props: Partial<ColorPickerBaseProps<string>>): JSX.Element => (
-  <AlphaColorPicker {...props} colorModel={colorModel} />
-);
+export const HexAlphaColorPicker = (
+  props: Partial<ColorPickerBaseProps<string>>
+): React.ReactElement => <AlphaColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/HexColorInput.tsx
+++ b/src/components/HexColorInput.tsx
@@ -14,7 +14,7 @@ interface HexColorInputProps extends ColorInputBaseProps {
 /** Adds "#" symbol to the beginning of the string */
 const prefix = (value: string) => "#" + value;
 
-export const HexColorInput = (props: HexColorInputProps): JSX.Element => {
+export const HexColorInput = (props: HexColorInputProps): React.ReactElement => {
   const { prefixed, alpha, ...rest } = props;
 
   /** Escapes all non-hexadecimal characters including "#" */

--- a/src/components/HexColorPicker.tsx
+++ b/src/components/HexColorPicker.tsx
@@ -12,6 +12,6 @@ const colorModel: ColorModel<string> = {
   equal: equalHex,
 };
 
-export const HexColorPicker = (props: Partial<ColorPickerBaseProps<string>>): JSX.Element => (
-  <ColorPicker {...props} colorModel={colorModel} />
-);
+export const HexColorPicker = (
+  props: Partial<ColorPickerBaseProps<string>>
+): React.ReactElement => <ColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/HslColorPicker.tsx
+++ b/src/components/HslColorPicker.tsx
@@ -12,6 +12,6 @@ const colorModel: ColorModel<HslColor> = {
   equal: equalColorObjects,
 };
 
-export const HslColorPicker = (props: Partial<ColorPickerBaseProps<HslColor>>): JSX.Element => (
-  <ColorPicker {...props} colorModel={colorModel} />
-);
+export const HslColorPicker = (
+  props: Partial<ColorPickerBaseProps<HslColor>>
+): React.ReactElement => <ColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/HslStringColorPicker.tsx
+++ b/src/components/HslStringColorPicker.tsx
@@ -12,6 +12,6 @@ const colorModel: ColorModel<string> = {
   equal: equalColorString,
 };
 
-export const HslStringColorPicker = (props: Partial<ColorPickerBaseProps<string>>): JSX.Element => (
-  <ColorPicker {...props} colorModel={colorModel} />
-);
+export const HslStringColorPicker = (
+  props: Partial<ColorPickerBaseProps<string>>
+): React.ReactElement => <ColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/HslaColorPicker.tsx
+++ b/src/components/HslaColorPicker.tsx
@@ -12,6 +12,6 @@ const colorModel: ColorModel<HslaColor> = {
   equal: equalColorObjects,
 };
 
-export const HslaColorPicker = (props: Partial<ColorPickerBaseProps<HslaColor>>): JSX.Element => (
-  <AlphaColorPicker {...props} colorModel={colorModel} />
-);
+export const HslaColorPicker = (
+  props: Partial<ColorPickerBaseProps<HslaColor>>
+): React.ReactElement => <AlphaColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/HslaStringColorPicker.tsx
+++ b/src/components/HslaStringColorPicker.tsx
@@ -14,4 +14,4 @@ const colorModel: ColorModel<string> = {
 
 export const HslaStringColorPicker = (
   props: Partial<ColorPickerBaseProps<string>>
-): JSX.Element => <AlphaColorPicker {...props} colorModel={colorModel} />;
+): React.ReactElement => <AlphaColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/HsvColorPicker.tsx
+++ b/src/components/HsvColorPicker.tsx
@@ -12,6 +12,6 @@ const colorModel: ColorModel<HsvColor> = {
   equal: equalColorObjects,
 };
 
-export const HsvColorPicker = (props: Partial<ColorPickerBaseProps<HsvColor>>): JSX.Element => (
-  <ColorPicker {...props} colorModel={colorModel} />
-);
+export const HsvColorPicker = (
+  props: Partial<ColorPickerBaseProps<HsvColor>>
+): React.ReactElement => <ColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/HsvStringColorPicker.tsx
+++ b/src/components/HsvStringColorPicker.tsx
@@ -12,6 +12,6 @@ const colorModel: ColorModel<string> = {
   equal: equalColorString,
 };
 
-export const HsvStringColorPicker = (props: Partial<ColorPickerBaseProps<string>>): JSX.Element => (
-  <ColorPicker {...props} colorModel={colorModel} />
-);
+export const HsvStringColorPicker = (
+  props: Partial<ColorPickerBaseProps<string>>
+): React.ReactElement => <ColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/HsvaColorPicker.tsx
+++ b/src/components/HsvaColorPicker.tsx
@@ -12,6 +12,6 @@ const colorModel: ColorModel<HsvaColor> = {
   equal: equalColorObjects,
 };
 
-export const HsvaColorPicker = (props: Partial<ColorPickerBaseProps<HsvaColor>>): JSX.Element => (
-  <AlphaColorPicker {...props} colorModel={colorModel} />
-);
+export const HsvaColorPicker = (
+  props: Partial<ColorPickerBaseProps<HsvaColor>>
+): React.ReactElement => <AlphaColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/HsvaStringColorPicker.tsx
+++ b/src/components/HsvaStringColorPicker.tsx
@@ -14,4 +14,4 @@ const colorModel: ColorModel<string> = {
 
 export const HsvaStringColorPicker = (
   props: Partial<ColorPickerBaseProps<string>>
-): JSX.Element => <AlphaColorPicker {...props} colorModel={colorModel} />;
+): React.ReactElement => <AlphaColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/RgbColorPicker.tsx
+++ b/src/components/RgbColorPicker.tsx
@@ -12,6 +12,6 @@ const colorModel: ColorModel<RgbColor> = {
   equal: equalColorObjects,
 };
 
-export const RgbColorPicker = (props: Partial<ColorPickerBaseProps<RgbColor>>): JSX.Element => (
-  <ColorPicker {...props} colorModel={colorModel} />
-);
+export const RgbColorPicker = (
+  props: Partial<ColorPickerBaseProps<RgbColor>>
+): React.ReactElement => <ColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/RgbStringColorPicker.tsx
+++ b/src/components/RgbStringColorPicker.tsx
@@ -12,6 +12,6 @@ const colorModel: ColorModel<string> = {
   equal: equalColorString,
 };
 
-export const RgbStringColorPicker = (props: Partial<ColorPickerBaseProps<string>>): JSX.Element => (
-  <ColorPicker {...props} colorModel={colorModel} />
-);
+export const RgbStringColorPicker = (
+  props: Partial<ColorPickerBaseProps<string>>
+): React.ReactElement => <ColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/RgbaColorPicker.tsx
+++ b/src/components/RgbaColorPicker.tsx
@@ -12,6 +12,6 @@ const colorModel: ColorModel<RgbaColor> = {
   equal: equalColorObjects,
 };
 
-export const RgbaColorPicker = (props: Partial<ColorPickerBaseProps<RgbaColor>>): JSX.Element => (
-  <AlphaColorPicker {...props} colorModel={colorModel} />
-);
+export const RgbaColorPicker = (
+  props: Partial<ColorPickerBaseProps<RgbaColor>>
+): React.ReactElement => <AlphaColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/RgbaStringColorPicker.tsx
+++ b/src/components/RgbaStringColorPicker.tsx
@@ -14,4 +14,4 @@ const colorModel: ColorModel<string> = {
 
 export const RgbaStringColorPicker = (
   props: Partial<ColorPickerBaseProps<string>>
-): JSX.Element => <AlphaColorPicker {...props} colorModel={colorModel} />;
+): React.ReactElement => <AlphaColorPicker {...props} colorModel={colorModel} />;

--- a/src/components/common/Alpha.tsx
+++ b/src/components/common/Alpha.tsx
@@ -15,7 +15,7 @@ interface Props {
   onChange: (newAlpha: { a: number }) => void;
 }
 
-export const Alpha = ({ className, hsva, onChange }: Props): JSX.Element => {
+export const Alpha = ({ className, hsva, onChange }: Props): React.ReactElement => {
   const handleMove = (interaction: Interaction) => {
     onChange({ a: interaction.left });
   };

--- a/src/components/common/AlphaColorPicker.tsx
+++ b/src/components/common/AlphaColorPicker.tsx
@@ -19,7 +19,7 @@ export const AlphaColorPicker = <T extends AnyColor>({
   color = colorModel.defaultColor,
   onChange,
   ...rest
-}: Props<T>): JSX.Element => {
+}: Props<T>): React.ReactElement => {
   const nodeRef = useRef<HTMLDivElement>(null);
   useStyleSheet(nodeRef);
 

--- a/src/components/common/ColorInput.tsx
+++ b/src/components/common/ColorInput.tsx
@@ -14,7 +14,7 @@ interface Props extends ColorInputBaseProps {
   process?: (value: string) => string;
 }
 
-export const ColorInput = (props: Props): JSX.Element => {
+export const ColorInput = (props: Props): React.ReactElement => {
   const { color = "", onChange, onBlur, escape, validate, format, process, ...rest } = props;
   const [value, setValue] = useState(() => escape(color));
   const onChangeCallback = useEventCallback<string>(onChange);

--- a/src/components/common/ColorPicker.tsx
+++ b/src/components/common/ColorPicker.tsx
@@ -18,7 +18,7 @@ export const ColorPicker = <T extends AnyColor>({
   color = colorModel.defaultColor,
   onChange,
   ...rest
-}: Props<T>): JSX.Element => {
+}: Props<T>): React.ReactElement => {
   const nodeRef = useRef<HTMLDivElement>(null);
   useStyleSheet(nodeRef);
 

--- a/src/components/common/Pointer.tsx
+++ b/src/components/common/Pointer.tsx
@@ -8,7 +8,7 @@ interface Props {
   color: string;
 }
 
-export const Pointer = ({ className, color, left, top = 0.5 }: Props): JSX.Element => {
+export const Pointer = ({ className, color, left, top = 0.5 }: Props): React.ReactElement => {
   const nodeClassName = formatClassName(["react-colorful__pointer", className]);
 
   const style = {


### PR DESCRIPTION
## Summary

Fixes #214

React 19's `@types/react` [removed the global `JSX` namespace](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#removed-deprecated-typescript-types), which breaks TypeScript compilation for consumers using React 19. This PR replaces `JSX.Element` return type annotations with `React.ReactElement` across all 20 component files.

### Why `React.ReactElement` over alternatives?

Several popular React libraries have tackled this same migration. The three common approaches are:

| Approach | Used by | Caveat |
|---|---|---|
| `JSX.Element` → `React.ReactElement` | [react-dropzone#1410](https://github.com/react-dropzone/react-dropzone/pull/1410) | None — type exists since earliest `@types/react` |
| `JSX.Element` → `React.JSX.Element` | [floating-ui#3050](https://github.com/floating-ui/floating-ui/pull/3050) | Requires `@types/react ≥16.14.41` |
| `import { JSX } from 'react'` | [react-select#5974](https://github.com/JedWatson/react-select/pull/5974) | Same version requirement as above |

`React.ReactElement` is the safest choice — it has existed since the very first `@types/react` versions and requires no minimum `@types/react` version, no import changes, and no runtime changes.

### What changed

A single-line change in each of the 20 component files:

```diff
-export const HexColorPicker = (props: ...): JSX.Element => (
+export const HexColorPicker = (props: ...): React.ReactElement => (
```

No import changes. No runtime changes. No peer dependency changes needed — the existing `"react": ">=16.8.0"` range already covers React 19.

## Verification

**Type checking against React 17, 18, and 19:**

Built the library and verified the emitted `.d.ts` files compile correctly in isolated projects using each major `@types/react` version:

| `@types/react` version | TypeScript compilation |
|---|---|
| `@types/react@17` | ✅ Pass |
| `@types/react@18` | ✅ Pass |
| `@types/react@19` | ✅ Pass |

**Existing test suite:**

All 57 tests pass with full coverage on all changed component files.

```
Test Suites: 3 passed, 3 total
Tests:       57 passed, 57 total
Snapshots:   5 passed, 5 total
```

**Build output:**

Library builds successfully. Emitted declarations use `React.ReactElement`:
```
export declare const HexColorPicker: (props: Partial<ColorPickerBaseProps<string>>) => React.ReactElement;
```

## Test plan

- [x] `tsc --noEmit` passes (React 17 dev types)
- [x] Emitted `.d.ts` compiles against `@types/react@17`
- [x] Emitted `.d.ts` compiles against `@types/react@18`
- [x] Emitted `.d.ts` compiles against `@types/react@19`
- [x] All 57 existing tests pass
- [x] Library builds with no errors